### PR TITLE
fix(helm): emit spec.tls + backend-protocol HTTPS when passthrough=false

### DIFF
--- a/helm/kubauth/templates/oidc/ingress.yaml
+++ b/helm/kubauth/templates/oidc/ingress.yaml
@@ -12,6 +12,8 @@ metadata:
     nginx.ingress.kubernetes.io/ssl-passthrough: "true"
     haproxy.org/ssl-passthrough: "true"
     ingress.kubernetes.io/ssl-passthrough: "true"
+    {{- else if .Values.oidc.server.tls }}
+    nginx.ingress.kubernetes.io/backend-protocol: HTTPS
     {{- end }}
     {{- with .Values.oidc.ingress.annotations }}
       {{- toYaml . | nindent 4 }}
@@ -21,6 +23,12 @@ metadata:
     {{- end }}
 spec:
   ingressClassName: {{ .Values.oidc.ingress.class }}
+  {{- if and (not .Values.oidc.ingress.passthrough) .Values.oidc.server.tls }}
+  tls:
+    - hosts:
+        - {{ required "oidc.ingress.host must be defined!" .Values.oidc.ingress.host }}
+      secretName: {{ include "kubauth.oidc.server.certificateSecretName" . }}
+  {{- end }}
   rules:
     - host: {{ required "oidc.ingress.host must be defined!" .Values.oidc.ingress.host }}
       http:


### PR DESCRIPTION
Fixes kubauth/kubauth#18.

When `passthrough=false` + `server.tls=true`, the chart now:
- adds `spec.tls` referencing the kubauth-issued cert secret
- adds `nginx.ingress.kubernetes.io/backend-protocol: HTTPS` annotation

Without these, nginx falls back to its fake cert and talks plaintext to a TLS-only backend — CORS annotations get dropped and browser OIDC clients cannot reach `/.well-known/openid-configuration`.