### PR TITLE
fix(oidc): resolve concurrent map writes in handleUserInfo + B5/B6/B7/B8 spec fixes

### DIFF
--- a/cmd/ldap/authenticator/authenticate.go
+++ b/cmd/ldap/authenticator/authenticate.go
@@ -78,7 +78,7 @@ func (l *ldapAuthenticator) Authenticate(ctx context.Context, request *proto.Ide
 		if uidStr != "" {
 			uid, err := strconv.Atoi(uidStr)
 			if err != nil {
-				logger.Error("Non numerical Uid value (%s) for user '%s'", uid, request.Login, "uid", uid, "login", request.Login)
+				logger.Error("Non numerical Uid value", "uidStr", uidStr, "login", request.Login, "error", err)
 			}
 			response.User.Uid = &uid
 		}

--- a/cmd/ldap/authenticator/authenticate.go
+++ b/cmd/ldap/authenticator/authenticate.go
@@ -78,9 +78,14 @@ func (l *ldapAuthenticator) Authenticate(ctx context.Context, request *proto.Ide
 		if uidStr != "" {
 			uid, err := strconv.Atoi(uidStr)
 			if err != nil {
+				// A non-numeric attribute is left unset rather than
+				// coerced to 0 — otherwise a malformed LDAP entry
+				// would silently become a valid-looking UID and
+				// affect downstream identity mapping.
 				logger.Error("Non numerical Uid value", "uidStr", uidStr, "login", request.Login, "error", err)
+			} else {
+				response.User.Uid = &uid
 			}
-			response.User.Uid = &uid
 		}
 		response.User.Emails = getAttrs(*ldapUser, l.config.UserSearch.EmailAttr)
 		response.User.Name = getAttr(*ldapUser, l.config.UserSearch.CnAttr)

--- a/cmd/oidc/fositepatch/compose2.go
+++ b/cmd/oidc/fositepatch/compose2.go
@@ -30,18 +30,25 @@ func ComposeAllEnabled(config *fosite.Config, storage fosite.Storage, key interf
 		return key, nil
 	}
 
+	// Wrap the OIDC token strategy with kubauth's scope-aware filter
+	// so id_tokens only carry Extra claims authorised by the granted
+	// scopes (OIDC §5.4). See scope_filter.go.
+	oidcTokenStrategy := NewScopeFilteringIDTokenStrategy(
+		compose.NewOpenIDConnectStrategy(keyGetter, config),
+	)
+
 	var strategy *compose.CommonStrategy
 	if jwtAccessToken {
 		strategy = &compose.CommonStrategy{
-			CoreStrategy:    compose.NewOAuth2JWTStrategy(keyGetter, compose.NewOAuth2HMACStrategy(config), config),
-			OIDCTokenStrategy: compose.NewOpenIDConnectStrategy(keyGetter, config),
-			Signer:          &jwt.DefaultSigner{GetPrivateKey: keyGetter},
+			CoreStrategy:      compose.NewOAuth2JWTStrategy(keyGetter, compose.NewOAuth2HMACStrategy(config), config),
+			OIDCTokenStrategy: oidcTokenStrategy,
+			Signer:            &jwt.DefaultSigner{GetPrivateKey: keyGetter},
 		}
 	} else {
 		strategy = &compose.CommonStrategy{
-			CoreStrategy:    compose.NewOAuth2HMACStrategy(config),
-			OIDCTokenStrategy: compose.NewOpenIDConnectStrategy(keyGetter, config),
-			Signer:          &jwt.DefaultSigner{GetPrivateKey: keyGetter},
+			CoreStrategy:      compose.NewOAuth2HMACStrategy(config),
+			OIDCTokenStrategy: oidcTokenStrategy,
+			Signer:            &jwt.DefaultSigner{GetPrivateKey: keyGetter},
 		}
 	}
 

--- a/cmd/oidc/fositepatch/scope_filter.go
+++ b/cmd/oidc/fositepatch/scope_filter.go
@@ -1,0 +1,144 @@
+/*
+Copyright (c) 2025 Kubotal.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fositepatch
+
+import (
+	"context"
+	"time"
+
+	"github.com/ory/hydra/v2/fosite"
+	"github.com/ory/hydra/v2/fosite/handler/openid"
+)
+
+// claimsByScope maps each standard OIDC scope to the set of Extra
+// claims it grants in the id_token (and the userinfo response).
+//
+// Reference: OpenID Connect Core 1.0 §5.4 "Requesting Claims using
+// Scope Values".
+//   https://openid.net/specs/openid-connect-core-1_0.html#ScopeClaims
+//
+// `openid` itself grants nothing in Extra — `sub` is a top-level
+// claim of IDTokenClaims, not an Extra entry.
+var claimsByScope = map[string][]string{
+	"profile": {
+		"name", "family_name", "given_name", "middle_name", "nickname",
+		"preferred_username", "profile", "picture", "website",
+		"gender", "birthdate", "zoneinfo", "locale", "updated_at",
+	},
+	"email":   {"email", "email_verified", "emails"},
+	"address": {"address"},
+	"phone":   {"phone_number", "phone_number_verified"},
+	// kubauth ships a `groups` scope: when granted, group membership
+	// shows up under the `groups` claim. Not in OIDC core, but
+	// follows the same scope→claim convention.
+	"groups": {"groups"},
+}
+
+// alwaysAllowedClaims are Extra entries that ride every id_token
+// regardless of scope. Two kinds:
+//
+//   - protocol-level (fosite/hydra populates them as part of the
+//     spec-defined token shape, not as user claims),
+//   - kubauth extensions that the existing e2e suite (and several
+//     downstream clients) rely on. These are emitted as a
+//     deliberate kubauth extension; the OpenID Conformance Suite
+//     flags them as non-requested but lets the test FINISHED with
+//     WARNING — acceptable.
+//
+// Notably absent: `rat` (hydra/fosite's "requested at"). Strict
+// OIDC RPs flag it; drop from id_token. Still observable via
+// `/oauth2/introspect` for clients that genuinely care.
+var alwaysAllowedClaims = map[string]struct{}{
+	// Protocol-level
+	"azp":       {}, // authorized party — kubauth adds it explicitly
+	"nonce":     {}, // echoed back from the auth request
+	"at_hash":   {},
+	"c_hash":    {},
+	"acr":       {},
+	"amr":       {},
+	"auth_time": {},
+	"sid":       {},
+	// Kubauth extensions
+	"authority": {}, // which IdP authority authenticated the user (ucrd/ldap/...)
+	"uid":       {}, // POSIX numeric uid (used by downstream tooling that maps OIDC sub → host user)
+}
+
+// AllowedIDTokenClaimsFor returns the union of Extra-claim names
+// that may appear in an id_token (or userinfo response) granted the
+// given scopes. Unknown scopes are ignored.
+//
+// Exposed so handle-user-info.go can mirror the id_token filter on
+// its own response.
+func AllowedIDTokenClaimsFor(grantedScopes []string) map[string]struct{} {
+	allowed := make(map[string]struct{}, 16)
+	for k := range alwaysAllowedClaims {
+		allowed[k] = struct{}{}
+	}
+	for _, sc := range grantedScopes {
+		for _, claim := range claimsByScope[sc] {
+			allowed[claim] = struct{}{}
+		}
+	}
+	return allowed
+}
+
+// FilterExtraClaimsByScope drops any Extra entry that's not in the
+// allowed set built from the granted scopes. Mutates and returns
+// the same map (or a fresh one if `extra` was nil).
+func FilterExtraClaimsByScope(extra map[string]interface{}, grantedScopes []string) map[string]interface{} {
+	if extra == nil {
+		return nil
+	}
+	allowed := AllowedIDTokenClaimsFor(grantedScopes)
+	for k := range extra {
+		if _, ok := allowed[k]; !ok {
+			delete(extra, k)
+		}
+	}
+	return extra
+}
+
+// scopeFilteringIDTokenStrategy wraps an OpenIDConnectTokenStrategy
+// and prunes the session's IDTokenClaims_.Extra to the claims the
+// granted scopes authorise. Without this, kubauth's id_token leaks
+// every user claim regardless of scope (OIDF conformance suite
+// trips on EnsureIdTokenDoesNotContainNonRequestedClaims for the
+// whole oidcc-basic plan).
+type scopeFilteringIDTokenStrategy struct {
+	inner openid.OpenIDConnectTokenStrategy
+}
+
+// NewScopeFilteringIDTokenStrategy decorates `inner` with the
+// scope-based Extra-claim filter described above.
+func NewScopeFilteringIDTokenStrategy(inner openid.OpenIDConnectTokenStrategy) openid.OpenIDConnectTokenStrategy {
+	return scopeFilteringIDTokenStrategy{inner: inner}
+}
+
+// GenerateIDToken filters the session's id_token Extra map by the
+// requester's granted scopes, then delegates to the wrapped
+// strategy.
+//
+// The session is the same object that handlers will serialise,
+// so mutating Extra here is safe — and necessary, since fosite's
+// default strategy hands the full Extra map straight into the JWT.
+func (s scopeFilteringIDTokenStrategy) GenerateIDToken(ctx context.Context, lifespan time.Duration, requester fosite.Requester) (string, error) {
+	if sess, ok := requester.GetSession().(*OIDCSession); ok && sess != nil && sess.IDTokenClaims_ != nil {
+		granted := requester.GetGrantedScopes()
+		sess.IDTokenClaims_.Extra = FilterExtraClaimsByScope(sess.IDTokenClaims_.Extra, granted)
+	}
+	return s.inner.GenerateIDToken(ctx, lifespan, requester)
+}

--- a/cmd/oidc/fositepatch/scope_filter.go
+++ b/cmd/oidc/fositepatch/scope_filter.go
@@ -98,7 +98,8 @@ func AllowedIDTokenClaimsFor(grantedScopes []string) map[string]struct{} {
 
 // FilterExtraClaimsByScope drops any Extra entry that's not in the
 // allowed set built from the granted scopes. Mutates and returns
-// the same map (or a fresh one if `extra` was nil).
+// the same map, or nil if `extra` was nil (no allocation in that
+// case — the caller's nil-handling stays explicit).
 func FilterExtraClaimsByScope(extra map[string]interface{}, grantedScopes []string) map[string]interface{} {
 	if extra == nil {
 		return nil

--- a/cmd/oidc/fositepatch/scope_filter.go
+++ b/cmd/oidc/fositepatch/scope_filter.go
@@ -96,21 +96,32 @@ func AllowedIDTokenClaimsFor(grantedScopes []string) map[string]struct{} {
 	return allowed
 }
 
-// FilterExtraClaimsByScope drops any Extra entry that's not in the
-// allowed set built from the granted scopes. Mutates and returns
-// the same map, or nil if `extra` was nil (no allocation in that
-// case — the caller's nil-handling stays explicit).
+// FilterExtraClaimsByScope returns a NEW map containing only the
+// Extra entries allowed by the granted scopes. The caller's input
+// map is not mutated.
+//
+// Why a copy rather than in-place delete: in fosite/hydra the same
+// underlying map can be referenced by multiple session views
+// (IDTokenClaims_.Extra, JWTClaims_.Extra, the cached SSO session
+// principal). In-place deletion here would silently strip claims
+// from access tokens / stored sessions and races with concurrent
+// readers — the same family of bug we just fixed in
+// handleUserInfo.
+//
+// Returns nil if `extra` was nil so the caller's nil-handling stays
+// explicit.
 func FilterExtraClaimsByScope(extra map[string]interface{}, grantedScopes []string) map[string]interface{} {
 	if extra == nil {
 		return nil
 	}
 	allowed := AllowedIDTokenClaimsFor(grantedScopes)
-	for k := range extra {
-		if _, ok := allowed[k]; !ok {
-			delete(extra, k)
+	filtered := make(map[string]interface{}, len(extra))
+	for k, v := range extra {
+		if _, ok := allowed[k]; ok {
+			filtered[k] = v
 		}
 	}
-	return extra
+	return filtered
 }
 
 // scopeFilteringIDTokenStrategy wraps an OpenIDConnectTokenStrategy

--- a/cmd/oidc/oidcserver/handle-login.go
+++ b/cmd/oidc/oidcserver/handle-login.go
@@ -20,8 +20,10 @@ import (
 	"kubauth/cmd/oidc/authenticator"
 	"kubauth/cmd/oidc/fositepatch"
 	"net/http"
+	"strings"
 
 	"github.com/go-logr/logr"
+	"github.com/ory/hydra/v2/fosite"
 )
 
 // Handle dedicated login endpoint for GET (render) and POST (authenticate)
@@ -33,33 +35,57 @@ func (s *OIDCServer) handleLogin(w http.ResponseWriter, r *http.Request) {
 	case http.MethodGet:
 		rawQuery := r.URL.RawQuery
 		clientId := r.URL.Query().Get("client_id")
-		logger.Debug("handleLogin(GET)", "clientID", clientId)
+		// OIDC Core 1.0 §3.1.2.1: `prompt` is a space-delimited
+		// list. Two values matter to us today:
+		//   - `none`: never display UI; return `login_required` if
+		//     the user isn't already authenticated.
+		//   - `login`: force re-authentication; don't auto-complete
+		//     the flow from an existing SSO session.
+		// `consent` and `select_account` are not implemented (kubauth
+		// has no consent UI and a session is one-user-per-session);
+		// silently ignored — clients that pass them still get a
+		// best-effort flow rather than an error.
+		promptValues := strings.Fields(r.URL.Query().Get("prompt"))
+		promptNone, promptLogin := false, false
+		for _, p := range promptValues {
+			switch p {
+			case "none":
+				promptNone = true
+			case "login":
+				promptLogin = true
+			}
+		}
+		logger.Debug("handleLogin(GET)", "clientID", clientId, "prompt", promptValues)
 
 		// Persist the authorization query in the session so the POST can retrieve it
 		s.LoginSessionManager.Put(ctx, "authQuery", rawQuery)
 		// For the index page.
 		s.LoginSessionManager.Put(ctx, "clientId", clientId)
 
-		// If user already authenticated (SSO), complete the OIDC flow directly
-		if v := s.SsoSessionManager.Get(ctx, "ssoUser"); v != nil {
-			u, ok := v.(map[string]interface{})
-			if ok {
-				if login, ok := u["Login"].(string); ok && login != "" {
-					claims := u["Claims"].(map[string]interface{})
-					if rawQuery != "" {
-						req, err := http.NewRequestWithContext(ctx, http.MethodGet, "/oauth2/auth?"+rawQuery, nil)
-						if err == nil {
-							ar, err := s.oauth2.NewAuthorizeRequest(ctx, req)
+		// If user already authenticated (SSO) AND the client didn't
+		// ask for re-authentication via `prompt=login`, complete the
+		// OIDC flow directly.
+		if !promptLogin {
+			if v := s.SsoSessionManager.Get(ctx, "ssoUser"); v != nil {
+				u, ok := v.(map[string]interface{})
+				if ok {
+					if login, ok := u["Login"].(string); ok && login != "" {
+						claims := u["Claims"].(map[string]interface{})
+						if rawQuery != "" {
+							req, err := http.NewRequestWithContext(ctx, http.MethodGet, "/oauth2/auth?"+rawQuery, nil)
 							if err == nil {
-								fositepatch.HandleScopes(ar, logger)
-								fositepatch.HandleAudience(ar, logger)
-
-								session := s.newSession(&authenticator.OidcUser{Login: login, Claims: claims}, clientId)
-								response, err := s.oauth2.NewAuthorizeResponse(ctx, ar, session)
+								ar, err := s.oauth2.NewAuthorizeRequest(ctx, req)
 								if err == nil {
-									logger.Info("Successfully logged in using existing SSO session", "login", login)
-									s.oauth2.WriteAuthorizeResponse(ctx, w, ar, response)
-									return
+									fositepatch.HandleScopes(ar, logger)
+									fositepatch.HandleAudience(ar, logger)
+
+									session := s.newSession(&authenticator.OidcUser{Login: login, Claims: claims}, clientId)
+									response, err := s.oauth2.NewAuthorizeResponse(ctx, ar, session)
+									if err == nil {
+										logger.Info("Successfully logged in using existing SSO session", "login", login)
+										s.oauth2.WriteAuthorizeResponse(ctx, w, ar, response)
+										return
+									}
 								}
 							}
 						}
@@ -67,6 +93,31 @@ func (s *OIDCServer) handleLogin(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 		}
+
+		// We're about to render the login page (no SSO bypass
+		// available, or `prompt=login` forced re-auth). If the
+		// client also said `prompt=none`, that's a contradiction —
+		// the spec says we MUST return `login_required` instead.
+		if promptNone {
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, "/oauth2/auth?"+rawQuery, nil)
+			if err == nil {
+				ar, arErr := s.oauth2.NewAuthorizeRequest(ctx, req)
+				if arErr == nil {
+					logger.Info("prompt=none with no active session — returning login_required",
+						"clientID", clientId)
+					s.oauth2.WriteAuthorizeError(ctx, w, ar, fosite.ErrLoginRequired)
+					return
+				}
+				// fosite refused the rebuilt request — surface its
+				// error rather than the prompt=none one; the client
+				// should fix its request first.
+				s.oauth2.WriteAuthorizeError(ctx, w, ar, arErr)
+				return
+			}
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+
 		// Otherwise, render login page
 		s.displayLoginResponse(ctx, w, r, clientId, false)
 		return

--- a/cmd/oidc/oidcserver/handle-login.go
+++ b/cmd/oidc/oidcserver/handle-login.go
@@ -55,6 +55,14 @@ func (s *OIDCServer) handleLogin(w http.ResponseWriter, r *http.Request) {
 				promptLogin = true
 			}
 		}
+		// OIDC Core 1.0 §3.1.2.1: `none` MUST NOT appear with any
+		// other prompt value. Reject early with `invalid_request`
+		// rather than letting downstream code emit a misleading
+		// `login_required` for what is actually a malformed request.
+		if promptNone && len(promptValues) > 1 {
+			http.Error(w, "invalid_request: prompt=none cannot be combined with other prompt values", http.StatusBadRequest)
+			return
+		}
 		logger.Debug("handleLogin(GET)", "clientID", clientId, "prompt", promptValues)
 
 		// Persist the authorization query in the session so the POST can retrieve it

--- a/cmd/oidc/oidcserver/handle-login.go
+++ b/cmd/oidc/oidcserver/handle-login.go
@@ -59,7 +59,26 @@ func (s *OIDCServer) handleLogin(w http.ResponseWriter, r *http.Request) {
 		// other prompt value. Reject early with `invalid_request`
 		// rather than letting downstream code emit a misleading
 		// `login_required` for what is actually a malformed request.
+		// Per §3.1.2.6, deliver the error via the redirect-based
+		// authorization error response when the request is parseable,
+		// so clients receive it on their `redirect_uri` rather than as
+		// a bare HTTP 400.
 		if promptNone && len(promptValues) > 1 {
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, "/oauth2/auth?"+rawQuery, nil)
+			if err == nil {
+				ar, arErr := s.oauth2.NewAuthorizeRequest(ctx, req)
+				if arErr == nil {
+					logger.Info("invalid prompt combination: prompt=none with other prompt values",
+						"clientID", clientId, "prompt", promptValues)
+					s.oauth2.WriteAuthorizeError(ctx, w, ar, fosite.ErrInvalidRequest.WithDescription("prompt=none cannot be combined with other prompt values"))
+					return
+				}
+				// fosite refused the rebuilt request — surface its
+				// error rather than the prompt-combination one; the
+				// client should fix its request first.
+				s.oauth2.WriteAuthorizeError(ctx, w, ar, arErr)
+				return
+			}
 			http.Error(w, "invalid_request: prompt=none cannot be combined with other prompt values", http.StatusBadRequest)
 			return
 		}

--- a/cmd/oidc/oidcserver/handle-logout.go
+++ b/cmd/oidc/oidcserver/handle-logout.go
@@ -19,6 +19,7 @@ package oidcserver
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/go-logr/logr"
 )
@@ -78,5 +79,38 @@ func (s *OIDCServer) handleLogout(w http.ResponseWriter, r *http.Request) {
 		logger.Error("failed to destroy local login session", "error", err, "errType", fmt.Sprintf("%T", err))
 	}
 	s.LoginSessionManager.Put(ctx, "clientId", clientId2)
+
+	// OIDC RP-Initiated Logout 1.0 §3: if `state` is included in the
+	// request, the OP MUST echo it on the redirect to
+	// post_logout_redirect_uri. Some RPs also expect `iss` (the
+	// auth-server-issuer-identification draft) — emit when the
+	// request asked for it.
+	postLogoutURL = appendLogoutQuery(postLogoutURL, r.URL.Query())
 	http.Redirect(w, r, postLogoutURL, http.StatusFound)
+}
+
+// appendLogoutQuery copies the OIDC RP-Initiated-Logout response
+// parameters (`state`, `iss`) from the incoming request's query
+// onto the post-logout redirect URL. Existing query params on the
+// postLogoutURL are preserved; the response params are appended.
+func appendLogoutQuery(postLogoutURL string, requestQuery url.Values) string {
+	state := requestQuery.Get("state")
+	if state == "" {
+		return postLogoutURL
+	}
+	u, err := url.Parse(postLogoutURL)
+	if err != nil {
+		// Bad URL configured — fall back to raw concatenation rather
+		// than dropping `state` silently. The browser will surface
+		// the malformed URL clearly enough.
+		sep := "?"
+		if u != nil && u.RawQuery != "" {
+			sep = "&"
+		}
+		return postLogoutURL + sep + "state=" + url.QueryEscape(state)
+	}
+	q := u.Query()
+	q.Set("state", state)
+	u.RawQuery = q.Encode()
+	return u.String()
 }

--- a/cmd/oidc/oidcserver/handle-logout.go
+++ b/cmd/oidc/oidcserver/handle-logout.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/go-logr/logr"
 )
@@ -107,9 +108,11 @@ func appendLogoutQuery(postLogoutURL string, requestQuery url.Values) string {
 	if err != nil {
 		// Bad URL configured — fall back to raw concatenation rather
 		// than dropping `state` silently. The browser will surface
-		// the malformed URL clearly enough.
+		// the malformed URL clearly enough. Use the raw string to
+		// pick the separator: `u` may be nil or partially populated
+		// when Parse fails, so its RawQuery is unreliable.
 		sep := "?"
-		if u != nil && u.RawQuery != "" {
+		if strings.Contains(postLogoutURL, "?") {
 			sep = "&"
 		}
 		return postLogoutURL + sep + "state=" + url.QueryEscape(state)

--- a/cmd/oidc/oidcserver/handle-logout.go
+++ b/cmd/oidc/oidcserver/handle-logout.go
@@ -82,21 +82,26 @@ func (s *OIDCServer) handleLogout(w http.ResponseWriter, r *http.Request) {
 
 	// OIDC RP-Initiated Logout 1.0 §3: if `state` is included in the
 	// request, the OP MUST echo it on the redirect to
-	// post_logout_redirect_uri. Some RPs also expect `iss` (the
-	// auth-server-issuer-identification draft) — emit when the
-	// request asked for it.
+	// post_logout_redirect_uri.
 	postLogoutURL = appendLogoutQuery(postLogoutURL, r.URL.Query())
 	http.Redirect(w, r, postLogoutURL, http.StatusFound)
 }
 
-// appendLogoutQuery copies the OIDC RP-Initiated-Logout response
-// parameters (`state`, `iss`) from the incoming request's query
-// onto the post-logout redirect URL. Existing query params on the
-// postLogoutURL are preserved; the response params are appended.
+// appendLogoutQuery copies the OIDC RP-Initiated-Logout `state`
+// response parameter from the incoming request's query onto the
+// post-logout redirect URL. Existing query params on the
+// postLogoutURL are preserved; `state` is appended/overwritten.
+// Per §3, `state` MUST be echoed when present in the request,
+// including an explicit empty value — so we check key presence
+// rather than the empty-string semantics of url.Values.Get.
 func appendLogoutQuery(postLogoutURL string, requestQuery url.Values) string {
-	state := requestQuery.Get("state")
-	if state == "" {
+	stateValues, hasState := requestQuery["state"]
+	if !hasState {
 		return postLogoutURL
+	}
+	state := ""
+	if len(stateValues) > 0 {
+		state = stateValues[0]
 	}
 	u, err := url.Parse(postLogoutURL)
 	if err != nil {

--- a/cmd/oidc/oidcserver/handle-user-info.go
+++ b/cmd/oidc/oidcserver/handle-user-info.go
@@ -32,13 +32,18 @@ func (s *OIDCServer) handleUserInfo(w http.ResponseWriter, r *http.Request) {
 	logger := logr.FromContextAsSlogLogger(ctx)
 
 	authz := r.Header.Get("Authorization")
-	if authz == "" || !strings.HasPrefix(authz, "Bearer ") {
+	// RFC 7235 §2.1: the auth scheme name is case-insensitive. The
+	// OpenID Conformance Suite (and some HTTP clients) sends a
+	// lowercase `bearer` prefix; reject only when the prefix is missing
+	// entirely, not when its case differs.
+	const bearerPrefix = "Bearer "
+	if len(authz) <= len(bearerPrefix) || !strings.EqualFold(authz[:len(bearerPrefix)], bearerPrefix) {
 		logger.Error("missing bearer token on userinfo handler")
 		w.Header().Set("WWW-Authenticate", "Bearer error=\"invalid_token\", error_description=\"missing bearer token\"")
 		http.Error(w, "unauthorized", http.StatusUnauthorized)
 		return
 	}
-	accessToken := strings.TrimPrefix(authz, "Bearer ")
+	accessToken := authz[len(bearerPrefix):]
 
 	_, ar, err := s.oauth2.IntrospectToken(ctx, accessToken, fosite.AccessToken, s.newSession(nil, GetClientIdFromRequest(r)), "openid")
 	if err != nil {
@@ -56,37 +61,24 @@ func (s *OIDCServer) handleUserInfo(w http.ResponseWriter, r *http.Request) {
 	}
 
 	idClaims := sess.IDTokenClaims_
-	claims := idClaims.Extra
-	if claims == nil {
-		claims = map[string]interface{}{}
-	}
-	delete(claims, "azp") // Remove, as not in user definition
-	claims["sub"] = idClaims.Subject
 
-	//claims := map[string]interface{}{
-	//	"sub": sess.Claims.Subject,
-	//}
-	//
-	//granted := map[string]struct{}{}
-	//for _, sc := range ar.GetGrantedScopes() {
-	//	granted[sc] = struct{}{}
-	//}
-	//
-	//if _, ok := granted["email"]; ok {
-	//	if v, ok2 := sess.Claims.Extra["email"]; ok2 {
-	//		claims["email"] = v
-	//	}
-	//}
-	//if _, ok := granted["profile"]; ok {
-	//	if v, ok2 := sess.Claims.Extra["name"]; ok2 {
-	//		claims["name"] = v
-	//	}
-	//}
-	//if _, ok := granted["groups"]; ok {
-	//	if v, ok2 := sess.Claims.Extra["groups"]; ok2 {
-	//		claims["groups"] = v
-	//	}
-	//}
+	// OIDC §5.4: a userinfo response may include claims only when
+	// the corresponding scope was granted. Filter the session's
+	// Extra map by the access token's granted scopes — see
+	// fositepatch.AllowedIDTokenClaimsFor for the scope→claim
+	// mapping kubauth uses (mirrors the id_token filter installed
+	// in fositepatch.NewScopeFilteringIDTokenStrategy).
+	allowed := fositepatch.AllowedIDTokenClaimsFor(ar.GetGrantedScopes())
+	claims := make(map[string]interface{}, len(idClaims.Extra)+1)
+	for k, v := range idClaims.Extra {
+		if _, ok := allowed[k]; ok {
+			claims[k] = v
+		}
+	}
+	delete(claims, "azp") // userinfo doesn't carry the authorized-party claim
+	// `sub` is mandatory in every userinfo response (OIDC §5.3.2);
+	// it lives on the top-level IDTokenClaims, not in Extra.
+	claims["sub"] = idClaims.Subject
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(claims)

--- a/cmd/oidc/oidcserver/handle-user-info.go
+++ b/cmd/oidc/oidcserver/handle-user-info.go
@@ -68,6 +68,12 @@ func (s *OIDCServer) handleUserInfo(w http.ResponseWriter, r *http.Request) {
 	// fositepatch.AllowedIDTokenClaimsFor for the scope→claim
 	// mapping kubauth uses (mirrors the id_token filter installed
 	// in fositepatch.NewScopeFilteringIDTokenStrategy).
+	//
+	// Note: the allowlist also includes kubauth-specific extensions
+	// (`authority`, `uid`) and protocol-level entries that ride every
+	// response regardless of scope — same policy as the id_token.
+	// `azp` is the only always-allowed claim explicitly stripped here
+	// since RFC 9068 reserves it for id_tokens.
 	allowed := fositepatch.AllowedIDTokenClaimsFor(ar.GetGrantedScopes())
 	claims := make(map[string]interface{}, len(idClaims.Extra)+1)
 	for k, v := range idClaims.Extra {

--- a/cmd/ucrd/authenticator/crdAuthenticator.go
+++ b/cmd/ucrd/authenticator/crdAuthenticator.go
@@ -59,7 +59,7 @@ func (c *crdAuthenticator) Authenticate(ctx context.Context, request *proto.Iden
 	groupBindingList := kubauthv1alpha1.GroupBindingList{}
 	err := c.k8sClient.List(ctx, &groupBindingList, client.MatchingFields{"userkey": request.Login}, client.InNamespace(c.userNamespace))
 	if err != nil {
-		return nil, fmt.Errorf("failed to list groupBindings for user %s: %w", request.Login)
+		return nil, fmt.Errorf("failed to list groupBindings for user %s: %w", request.Login, err)
 	}
 	// Sort groupBindings by group name, to have a predictable claims merge
 	sort.Slice(groupBindingList.Items, func(i, j int) bool {

--- a/internal/httpsrv/httpsrv.go
+++ b/internal/httpsrv/httpsrv.go
@@ -144,7 +144,7 @@ func (hs *httpServer) Start(ctx context.Context) error {
 	if err != nil && !errors.Is(err, http.ErrServerClosed) {
 		return fmt.Errorf("httpServer %s: Error on srv.Serve(): %w", hs.name, err)
 	}
-	logger.Info("httpServer shutdown", "name", hs.name)
+	logger.Info("httpServer shutdown")
 	<-idleConsClosed
 	return nil
 

--- a/internal/httpsrv/httpsrv.go
+++ b/internal/httpsrv/httpsrv.go
@@ -144,7 +144,7 @@ func (hs *httpServer) Start(ctx context.Context) error {
 	if err != nil && !errors.Is(err, http.ErrServerClosed) {
 		return fmt.Errorf("httpServer %s: Error on srv.Serve(): %w", hs.name, err)
 	}
-	logger.Info("httpServer %s shutdown", hs.name)
+	logger.Info("httpServer shutdown", "name", hs.name)
 	<-idleConsClosed
 	return nil
 


### PR DESCRIPTION
- Concurrent map writes in `handleUserInfo` → new claims map per request
- 4 OIDC spec compliance fixes (B5/B6/B7/B8-partial) + 3 latent vet bugs

Validated in local cluster on tag `0.3.0-fix-userinfo-20260525`.