### PR TITLE
fix(oidc): copy claims map in handleUserInfo to avoid concurrent map writes

### DIFF
--- a/cmd/oidc/oidcserver/handle-user-info.go
+++ b/cmd/oidc/oidcserver/handle-user-info.go
@@ -56,11 +56,13 @@ func (s *OIDCServer) handleUserInfo(w http.ResponseWriter, r *http.Request) {
 	}
 
 	idClaims := sess.IDTokenClaims_
-	claims := idClaims.Extra
-	if claims == nil {
-		claims = map[string]interface{}{}
+	claims := make(map[string]interface{}, len(idClaims.Extra)+1)
+	for k, v := range idClaims.Extra {
+		if k == "azp" {
+			continue
+		}
+		claims[k] = v
 	}
-	delete(claims, "azp") // Remove, as not in user definition
 	claims["sub"] = idClaims.Subject
 
 	//claims := map[string]interface{}{


### PR DESCRIPTION
Fixes #25

`handleUserInfo` mutated the shared `sess.IDTokenClaims_.Extra` map in-place (`delete azp`, set `sub`), causing `panic: concurrent map writes` -> HTTP 500 under concurrent `/userinfo` requests.

Fix: copy claims into a fresh map before mutating. ~6 line diff, single file.