### PR TITLE
test: unit tests for OIDC core, auth providers and supporting packages

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,3 +12,12 @@ linters:
     # Skip machine-generated files (zz_generated.deepcopy.go, etc.). This is the
     # v2 default; pinned here so a config change can't silently start linting them.
     generated: lax
+    rules:
+      # Test files legitimately hold fixture credentials (gosec G101), write
+      # world-readable temp files (G306), and exercise error paths where the
+      # HTTP response is nil (bodyclose false positives). Production code stays
+      # strict. Only tests are relaxed for these two linters.
+      - path: _test\.go
+        linters:
+          - bodyclose
+          - gosec

--- a/cmd/audit/authenticator/auditauthenticator_test.go
+++ b/cmd/audit/authenticator/auditauthenticator_test.go
@@ -1,0 +1,216 @@
+/*
+Copyright (c) 2025 Kubotal.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package authenticator
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"testing"
+
+	kubauthv1alpha1 "kubauth/api/kubauth/v1alpha1"
+	"kubauth/internal/httpclient"
+	"kubauth/internal/proto"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+)
+
+const testNS = "kubauth-ns"
+
+func testCtx() context.Context {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	return logr.NewContextWithSlogLogger(context.Background(), logger)
+}
+
+func newScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := kubauthv1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+	return s
+}
+
+// idpServer answers the v1/identity exchange with resp.
+func idpServer(t *testing.T, resp proto.IdentityResponse) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Errorf("encode response: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func listAttempts(t *testing.T, c client.Client) []kubauthv1alpha1.LoginAttempt {
+	t.Helper()
+	var list kubauthv1alpha1.LoginAttemptList
+	if err := c.List(context.Background(), &list, client.InNamespace(testNS)); err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	return list.Items
+}
+
+func TestAuthenticate_PassThroughAndCreatesRecord(t *testing.T) {
+	uid := 501
+	resp := proto.IdentityResponse{
+		Status:    proto.PasswordChecked,
+		Authority: "ldap",
+		User: proto.User{
+			Login:  "alice",
+			Name:   "Alice",
+			Uid:    &uid,
+			Emails: []string{"a@corp.io"},
+			Groups: []string{"dev"},
+			Claims: map[string]interface{}{"team": "blue"},
+		},
+	}
+	fc := fake.NewClientBuilder().WithScheme(newScheme(t)).Build()
+	a, err := New(&httpclient.Config{BaseURL: idpServer(t, resp).URL}, fc, testNS)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	got, err := a.Authenticate(testCtx(), &proto.IdentityRequest{Login: "alice", Password: "pw"})
+	if err != nil {
+		t.Fatalf("Authenticate: %v", err)
+	}
+	// Pass-through of the upstream response.
+	if got.User.Login != "alice" || got.Status != proto.PasswordChecked {
+		t.Errorf("response = {login:%q status:%q}, want {alice passwordChecked}", got.User.Login, got.Status)
+	}
+	// A LoginAttempt record was written.
+	items := listAttempts(t, fc)
+	if len(items) != 1 {
+		t.Fatalf("LoginAttempt count = %d, want 1", len(items))
+	}
+	la := items[0]
+	if la.Spec.User.Login != "alice" {
+		t.Errorf("record login = %q, want alice", la.Spec.User.Login)
+	}
+	if la.Spec.Status != string(proto.PasswordChecked) {
+		t.Errorf("record status = %q, want passwordChecked", la.Spec.Status)
+	}
+	if la.Spec.Authority != "ldap" {
+		t.Errorf("record authority = %q, want ldap", la.Spec.Authority)
+	}
+	if la.Labels["kubauth.kubotal.io/login"] != "alice" {
+		t.Errorf("record login label = %q, want alice", la.Labels["kubauth.kubotal.io/login"])
+	}
+	if la.Spec.User.Claims == nil {
+		t.Error("record claims JSON not stored")
+	}
+}
+
+func TestAuthenticate_FailOpenWhenRecordCreationFails(t *testing.T) {
+	resp := proto.IdentityResponse{
+		Status: proto.PasswordChecked,
+		User:   proto.User{Login: "bob", Claims: map[string]interface{}{}},
+	}
+	fc := fake.NewClientBuilder().
+		WithScheme(newScheme(t)).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(_ context.Context, _ client.WithWatch, _ client.Object, _ ...client.CreateOption) error {
+				return errors.New("apiserver down")
+			},
+		}).
+		Build()
+	a, err := New(&httpclient.Config{BaseURL: idpServer(t, resp).URL}, fc, testNS)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	got, err := a.Authenticate(testCtx(), &proto.IdentityRequest{Login: "bob", Password: "pw"})
+	if err != nil {
+		t.Fatalf("audit-record failure must NOT fail authentication (fail-open): %v", err)
+	}
+	if got == nil || got.User.Login != "bob" {
+		t.Errorf("response = %+v, want authenticated bob despite record failure", got)
+	}
+}
+
+func TestAuthenticate_HTTPErrorPropagatesAndWritesNoRecord(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+	fc := fake.NewClientBuilder().WithScheme(newScheme(t)).Build()
+	a, err := New(&httpclient.Config{BaseURL: srv.URL}, fc, testNS)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	got, err := a.Authenticate(testCtx(), &proto.IdentityRequest{Login: "x", Password: "pw"})
+	if err == nil {
+		t.Fatal("upstream HTTP failure must propagate as an error")
+	}
+	if got != nil {
+		t.Errorf("want nil response on HTTP failure, got %+v", got)
+	}
+	if n := len(listAttempts(t, fc)); n != 0 {
+		t.Errorf("LoginAttempt count = %d, want 0 (no record on failed exchange)", n)
+	}
+}
+
+func TestAuthenticate_MapsDetails(t *testing.T) {
+	uid, tuid := 7, 8
+	resp := proto.IdentityResponse{
+		Status: proto.PasswordChecked,
+		User:   proto.User{Login: "carol", Claims: map[string]interface{}{}},
+		Details: []*proto.UserDetail{{
+			Provider: proto.ProviderSpec{Name: "ldap", GroupAuthority: true, ClaimAuthority: true},
+			User:     proto.User{Login: "carol", Uid: &uid, Name: "Carol", Groups: []string{"g1"}, Emails: []string{"c@corp.io"}, Claims: map[string]interface{}{"k": "v"}},
+			Status:   proto.PasswordChecked,
+			Translated: proto.Translated{
+				Groups: []string{"ext:g1"},
+				Uid:    &tuid,
+				Claims: map[string]interface{}{"tk": "tv"},
+			},
+		}},
+	}
+	fc := fake.NewClientBuilder().WithScheme(newScheme(t)).Build()
+	a, err := New(&httpclient.Config{BaseURL: idpServer(t, resp).URL}, fc, testNS)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if _, err := a.Authenticate(testCtx(), &proto.IdentityRequest{Login: "carol", Password: "pw"}); err != nil {
+		t.Fatalf("Authenticate: %v", err)
+	}
+
+	la := listAttempts(t, fc)[0]
+	if len(la.Spec.Details) != 1 {
+		t.Fatalf("details count = %d, want 1", len(la.Spec.Details))
+	}
+	d := la.Spec.Details[0]
+	if d.Provider.Name != "ldap" {
+		t.Errorf("detail provider = %q, want ldap", d.Provider.Name)
+	}
+	if d.User.Login != "carol" {
+		t.Errorf("detail user = %q, want carol", d.User.Login)
+	}
+	if d.Status != string(proto.PasswordChecked) {
+		t.Errorf("detail status = %q, want passwordChecked", d.Status)
+	}
+	if !slices.Equal(d.Translated.Groups, []string{"ext:g1"}) {
+		t.Errorf("detail translated groups = %v, want [ext:g1]", d.Translated.Groups)
+	}
+	if d.Translated.Uid == nil || *d.Translated.Uid != tuid {
+		t.Errorf("detail translated uid = %v, want %d", d.Translated.Uid, tuid)
+	}
+}

--- a/cmd/audit/authenticator/auditauthenticator_test.go
+++ b/cmd/audit/authenticator/auditauthenticator_test.go
@@ -114,7 +114,14 @@ func TestAuthenticate_PassThroughAndCreatesRecord(t *testing.T) {
 		t.Errorf("record login label = %q, want alice", la.Labels["kubauth.kubotal.io/login"])
 	}
 	if la.Spec.User.Claims == nil {
-		t.Error("record claims JSON not stored")
+		t.Fatal("record claims JSON not stored")
+	}
+	var gotClaims map[string]interface{}
+	if err := json.Unmarshal(la.Spec.User.Claims.Raw, &gotClaims); err != nil {
+		t.Fatalf("record claims JSON unmarshal: %v", err)
+	}
+	if gotClaims["team"] != "blue" {
+		t.Errorf("record claims = %v, want team=blue", gotClaims)
 	}
 }
 
@@ -193,7 +200,11 @@ func TestAuthenticate_MapsDetails(t *testing.T) {
 		t.Fatalf("Authenticate: %v", err)
 	}
 
-	la := listAttempts(t, fc)[0]
+	items := listAttempts(t, fc)
+	if len(items) != 1 {
+		t.Fatalf("LoginAttempt count = %d, want 1", len(items))
+	}
+	la := items[0]
 	if len(la.Spec.Details) != 1 {
 		t.Fatalf("details count = %d, want 1", len(la.Spec.Details))
 	}

--- a/cmd/audit/cleaner_test.go
+++ b/cmd/audit/cleaner_test.go
@@ -1,0 +1,182 @@
+/*
+Copyright (c) 2025 Kubotal.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package audit
+
+import (
+	"context"
+	"io"
+	kubauthv1alpha1 "kubauth/api/kubauth/v1alpha1"
+	"log/slog"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// helpers ----------------------------------------------------------------
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// newFakeClient returns a controller-runtime fake client wired with the
+// kubauth v1alpha1 scheme and the supplied seed objects. Sub-tests use
+// this to build deterministic LoginAttempt fixtures without standing up
+// a real apiserver.
+func newFakeClient(t *testing.T, seed ...client.Object) client.Client {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := kubauthv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+	return fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(seed...).
+		Build()
+}
+
+func loginAttempt(name, ns string, when time.Time) *kubauthv1alpha1.LoginAttempt {
+	return &kubauthv1alpha1.LoginAttempt{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+		Spec: kubauthv1alpha1.LoginAttemptSpec{
+			When: metav1.NewTime(when),
+			User: kubauthv1alpha1.LoginAttemptUser{Login: "alice"},
+		},
+	}
+}
+
+// withAuditParams sets the global audit params for the duration of the
+// test, restoring the previous values on cleanup. Required because
+// cleanupAudit reads them directly (no DI) — keeping tests hermetic
+// without changing the production signature.
+func withAuditParams(t *testing.T, ns string, lifetime time.Duration) {
+	t.Helper()
+	prevNs := auditParams.namespace
+	prevLifetime := auditParams.recordLifetime
+	auditParams.namespace = ns
+	auditParams.recordLifetime = lifetime
+	t.Cleanup(func() {
+		auditParams.namespace = prevNs
+		auditParams.recordLifetime = prevLifetime
+	})
+}
+
+func listAttempts(t *testing.T, c client.Client, ns string) []string {
+	t.Helper()
+	var list kubauthv1alpha1.LoginAttemptList
+	if err := c.List(context.Background(), &list, client.InNamespace(ns)); err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	out := make([]string, 0, len(list.Items))
+	for _, a := range list.Items {
+		out = append(out, a.Name)
+	}
+	return out
+}
+
+// tests ------------------------------------------------------------------
+
+func TestCleanupAudit_DeletesOnlyExpired(t *testing.T) {
+	ns := "kubauth-system"
+	withAuditParams(t, ns, time.Hour) // lifetime = 1h
+
+	now := time.Now()
+	c := newFakeClient(t,
+		loginAttempt("old-1", ns, now.Add(-2*time.Hour)),    // expired
+		loginAttempt("old-2", ns, now.Add(-90*time.Minute)), // expired
+		loginAttempt("fresh", ns, now.Add(-5*time.Minute)),  // kept
+	)
+
+	cleanupAudit(context.Background(), c, discardLogger())
+
+	got := listAttempts(t, c, ns)
+	if len(got) != 1 || got[0] != "fresh" {
+		t.Errorf("expected only 'fresh' to remain, got %v", got)
+	}
+}
+
+func TestCleanupAudit_NoExpiredKeepsAll(t *testing.T) {
+	ns := "kubauth-system"
+	withAuditParams(t, ns, time.Hour)
+
+	now := time.Now()
+	c := newFakeClient(t,
+		loginAttempt("a", ns, now.Add(-10*time.Minute)),
+		loginAttempt("b", ns, now.Add(-30*time.Minute)),
+	)
+
+	cleanupAudit(context.Background(), c, discardLogger())
+
+	got := listAttempts(t, c, ns)
+	if len(got) != 2 {
+		t.Errorf("expected both records to remain, got %v", got)
+	}
+}
+
+func TestCleanupAudit_AllExpiredDeletesAll(t *testing.T) {
+	ns := "kubauth-system"
+	withAuditParams(t, ns, time.Minute) // very short lifetime
+
+	now := time.Now()
+	c := newFakeClient(t,
+		loginAttempt("a", ns, now.Add(-1*time.Hour)),
+		loginAttempt("b", ns, now.Add(-2*time.Hour)),
+		loginAttempt("c", ns, now.Add(-30*time.Minute)),
+	)
+
+	cleanupAudit(context.Background(), c, discardLogger())
+
+	got := listAttempts(t, c, ns)
+	if len(got) != 0 {
+		t.Errorf("expected all records deleted, got %v", got)
+	}
+}
+
+func TestCleanupAudit_RespectsNamespace(t *testing.T) {
+	// cleanupAudit must only touch records in auditParams.namespace —
+	// LoginAttempts in other namespaces (multi-tenant kubauth deploys)
+	// must not be touched.
+	target := "ns-target"
+	other := "ns-other"
+	withAuditParams(t, target, time.Hour)
+
+	now := time.Now()
+	c := newFakeClient(t,
+		loginAttempt("expired-target", target, now.Add(-2*time.Hour)),
+		loginAttempt("expired-other", other, now.Add(-2*time.Hour)),
+	)
+
+	cleanupAudit(context.Background(), c, discardLogger())
+
+	if got := listAttempts(t, c, target); len(got) != 0 {
+		t.Errorf("target namespace not cleaned: %v", got)
+	}
+	if got := listAttempts(t, c, other); len(got) != 1 || got[0] != "expired-other" {
+		t.Errorf("other namespace should be untouched, got %v", got)
+	}
+}
+
+func TestCleanupAudit_EmptyListIsNoOp(t *testing.T) {
+	ns := "kubauth-system"
+	withAuditParams(t, ns, time.Hour)
+
+	c := newFakeClient(t)
+
+	// Should not panic, should not error.
+	cleanupAudit(context.Background(), c, discardLogger())
+
+	if got := listAttempts(t, c, ns); len(got) != 0 {
+		t.Errorf("expected empty list, got %v", got)
+	}
+}

--- a/cmd/audit/cleaner_test.go
+++ b/cmd/audit/cleaner_test.go
@@ -8,10 +8,14 @@ you may not use this file except in compliance with the License.
 package audit
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"io"
 	kubauthv1alpha1 "kubauth/api/kubauth/v1alpha1"
 	"log/slog"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -19,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
 // helpers ----------------------------------------------------------------
@@ -178,5 +183,118 @@ func TestCleanupAudit_EmptyListIsNoOp(t *testing.T) {
 
 	if got := listAttempts(t, c, ns); len(got) != 0 {
 		t.Errorf("expected empty list, got %v", got)
+	}
+}
+
+// failure tolerance: List/Delete errors must not crash the cleaner -------
+
+// safeBuf is an io.Writer safe for the (single-goroutine here, but
+// belt-and-suspenders) slog handler to write into while a test reads it.
+type safeBuf struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (s *safeBuf) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.Write(p)
+}
+
+func (s *safeBuf) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.String()
+}
+
+// capturingLogger returns a slog.Logger writing into buf, so a test can
+// assert on the structured fields cleanupAudit logs (e.g. deletedCount,
+// errorCount) which are otherwise not externally observable.
+func capturingLogger(buf io.Writer) *slog.Logger {
+	return slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+}
+
+func TestCleanupAudit_ListErrorIsSafeNoOp(t *testing.T) {
+	// SECURITY/robustness: a List failure (apiserver hiccup, RBAC) must be
+	// a safe no-op: zero deletions, no panic, and the records left intact.
+	// Deleting on a failed list would be data loss against a partial/empty
+	// view; here we assert nothing is deleted at all.
+	ns := "kubauth-system"
+	withAuditParams(t, ns, time.Minute) // everything below is "expired"
+
+	now := time.Now()
+	seeded := newFakeClient(t,
+		loginAttempt("old-1", ns, now.Add(-2*time.Hour)),
+		loginAttempt("old-2", ns, now.Add(-3*time.Hour)),
+	)
+	listErr := errors.New("list boom")
+	c := interceptor.NewClient(seeded.(client.WithWatch), interceptor.Funcs{
+		List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error {
+			return listErr
+		},
+	})
+
+	var buf safeBuf
+	// Must not panic despite the failing List.
+	cleanupAudit(context.Background(), c, capturingLogger(&buf))
+
+	// Records survive: verify directly against the underlying client whose
+	// List still works (the interceptor only wraps `c`).
+	if got := listAttempts(t, seeded, ns); len(got) != 2 {
+		t.Errorf("List error must delete nothing, got survivors=%v", got)
+	}
+	logs := buf.String()
+	if !strings.Contains(logs, "Failed to list login records for cleanup") {
+		t.Errorf("expected the list-failure to be logged, logs=%q", logs)
+	}
+	// And it returned early: no "cleanup completed" summary line.
+	if strings.Contains(logs, "cleanup completed") {
+		t.Errorf("List error path must return before the completion summary, logs=%q", logs)
+	}
+}
+
+func TestCleanupAudit_DeleteErrorIsToleratedAndTallied(t *testing.T) {
+	// Robustness: a Delete failure on one expired record must NOT abort the
+	// run. The cleaner continues, deletes the records it can, tolerates the
+	// error (no panic, normal return) and tallies it as errorCount=1.
+	ns := "kubauth-system"
+	withAuditParams(t, ns, time.Minute) // all three records are expired
+
+	now := time.Now()
+	seeded := newFakeClient(t,
+		loginAttempt("boom", ns, now.Add(-2*time.Hour)),    // Delete will fail
+		loginAttempt("ok-1", ns, now.Add(-3*time.Hour)),    // deletable
+		loginAttempt("ok-2", ns, now.Add(-90*time.Minute)), // deletable
+	)
+	delErr := errors.New("delete boom")
+	c := interceptor.NewClient(seeded.(client.WithWatch), interceptor.Funcs{
+		Delete: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+			if obj.GetName() == "boom" {
+				return delErr
+			}
+			return cl.Delete(ctx, obj, opts...) // delegate: actually delete the others
+		},
+	})
+
+	var buf safeBuf
+	// Must not panic, must return normally despite the Delete error.
+	cleanupAudit(context.Background(), c, capturingLogger(&buf))
+
+	// "boom" survives (its delete failed), the two deletable ones are gone:
+	// proof that the loop CONTINUED past the failing record.
+	got := listAttempts(t, seeded, ns)
+	if len(got) != 1 || got[0] != "boom" {
+		t.Errorf("expected only 'boom' to survive a tolerated delete error, got %v", got)
+	}
+	logs := buf.String()
+	// The error is tallied (errorCount=1) and 2 deletions succeeded.
+	if !strings.Contains(logs, "errorCount=1") {
+		t.Errorf("delete error should be tallied as errorCount=1, logs=%q", logs)
+	}
+	if !strings.Contains(logs, "deletedCount=2") {
+		t.Errorf("cleaner should have deleted the other 2 records, logs=%q", logs)
+	}
+	if !strings.Contains(logs, "Failed to delete expired loginAttempt record") {
+		t.Errorf("the per-record delete failure should be logged, logs=%q", logs)
 	}
 }

--- a/cmd/merger/authenticator/authenticator_test.go
+++ b/cmd/merger/authenticator/authenticator_test.go
@@ -1,0 +1,693 @@
+/*
+Copyright (c) 2025 Kubotal.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package authenticator
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"reflect"
+	"testing"
+
+	"kubauth/cmd/merger/provider"
+	"kubauth/internal/proto"
+
+	"github.com/go-logr/logr"
+)
+
+// ---------------------------------------------------------------------------
+// Fakes & helpers
+// ---------------------------------------------------------------------------
+
+// fakeProvider is a canned provider.Provider. GetUserDetail ignores the
+// login/password and returns the pre-built detail (or err). It records how
+// many times it was called so we can assert short-circuit behaviour.
+type fakeProvider struct {
+	name   string
+	detail *proto.UserDetail
+	err    error
+	calls  int
+}
+
+var _ provider.Provider = (*fakeProvider)(nil)
+
+func (f *fakeProvider) GetUserDetail(_ context.Context, _, _ string) (*proto.UserDetail, error) {
+	f.calls++
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.detail, nil
+}
+
+func (f *fakeProvider) GetName() string { return f.name }
+
+// testCtx mirrors the sibling authenticator tests: a discarding slog logger
+// wired into the context so Authenticate's logr.FromContextOrDiscard is happy.
+func testCtx() context.Context {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	return logr.NewContextWithSlogLogger(context.Background(), logger)
+}
+
+// detailOpt mutates a UserDetail under construction.
+type detailOpt func(*proto.UserDetail)
+
+func withCredentialAuthority(v bool) detailOpt {
+	return func(d *proto.UserDetail) { d.Provider.CredentialAuthority = v }
+}
+func withGroupAuthority(v bool) detailOpt {
+	return func(d *proto.UserDetail) { d.Provider.GroupAuthority = v }
+}
+func withEmailAuthority(v bool) detailOpt {
+	return func(d *proto.UserDetail) { d.Provider.EmailAuthority = v }
+}
+func withNameAuthority(v bool) detailOpt {
+	return func(d *proto.UserDetail) { d.Provider.NameAuthority = v }
+}
+func withClaimAuthority(v bool) detailOpt {
+	return func(d *proto.UserDetail) { d.Provider.ClaimAuthority = v }
+}
+func withTranslatedUID(uid int) detailOpt {
+	return func(d *proto.UserDetail) { d.Translated.Uid = &uid }
+}
+func withTranslatedGroups(g ...string) detailOpt {
+	return func(d *proto.UserDetail) { d.Translated.Groups = g }
+}
+func withTranslatedClaims(c map[string]interface{}) detailOpt {
+	return func(d *proto.UserDetail) { d.Translated.Claims = c }
+}
+func withUserEmails(e ...string) detailOpt {
+	return func(d *proto.UserDetail) { d.User.Emails = e }
+}
+func withUserName(n string) detailOpt {
+	return func(d *proto.UserDetail) { d.User.Name = n }
+}
+
+// newDetail builds a UserDetail with the given provider name + status and
+// applies the options. The embedded User.Login is always the supplied login.
+func newDetail(name, login string, status proto.Status, opts ...detailOpt) *proto.UserDetail {
+	d := &proto.UserDetail{
+		User:   proto.InitUser(login),
+		Status: status,
+		Provider: proto.ProviderSpec{
+			Name: name,
+		},
+		Translated: proto.Translated{
+			Groups: []string{},
+			Claims: map[string]interface{}{},
+		},
+	}
+	for _, o := range opts {
+		o(d)
+	}
+	return d
+}
+
+// newMerger wires a mergerAuthenticator from raw providers (same package, so
+// we can reach the unexported field directly).
+func newMerger(ps ...provider.Provider) *mergerAuthenticator {
+	return &mergerAuthenticator{providers: ps}
+}
+
+const login = "alice"
+
+// ---------------------------------------------------------------------------
+// Empty / baseline
+// ---------------------------------------------------------------------------
+
+func TestAuthenticate_NoProviders(t *testing.T) {
+	m := newMerger()
+	resp, err := m.Authenticate(testCtx(), &proto.IdentityRequest{Login: login})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Status != proto.UserNotFound {
+		t.Errorf("status = %q, want %q", resp.Status, proto.UserNotFound)
+	}
+	if resp.Authority != "" {
+		t.Errorf("authority = %q, want empty", resp.Authority)
+	}
+	if resp.User.Login != login {
+		t.Errorf("login = %q, want %q", resp.User.Login, login)
+	}
+	if resp.User.Uid != nil {
+		t.Errorf("uid = %v, want nil", *resp.User.Uid)
+	}
+	if len(resp.Details) != 0 {
+		t.Errorf("details len = %d, want 0", len(resp.Details))
+	}
+	// InitUser gives empty (non-nil) groups; DedupAndSort keeps them empty.
+	if len(resp.User.Groups) != 0 {
+		t.Errorf("groups = %v, want empty", resp.User.Groups)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CredentialAuthority gating — the core contract
+// ---------------------------------------------------------------------------
+
+// A NON-authority provider must never move response.Status, even when it
+// reports a strictly higher-priority outcome (here Disabled, the max).
+func TestAuthenticate_NonAuthorityCannotOverrideStatus(t *testing.T) {
+	nonAuth := &fakeProvider{
+		name:   "ldap-readonly",
+		detail: newDetail("ldap-readonly", login, proto.Disabled, withCredentialAuthority(false), withTranslatedUID(999)),
+	}
+	m := newMerger(nonAuth)
+	resp, err := m.Authenticate(testCtx(), &proto.IdentityRequest{Login: login})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Status stays at the initial UserNotFound — the Disabled was ignored.
+	if resp.Status != proto.UserNotFound {
+		t.Errorf("status = %q, want %q (non-authority must not override)", resp.Status, proto.UserNotFound)
+	}
+	if resp.Authority != "" {
+		t.Errorf("authority = %q, want empty (non-authority must not set authority)", resp.Authority)
+	}
+	if resp.User.Uid != nil {
+		t.Errorf("uid = %v, want nil (non-authority must not set uid)", *resp.User.Uid)
+	}
+}
+
+// The decisive case: an authority provider says PasswordChecked, a
+// non-authority provider (ordered AFTER it) says Disabled. The non-authority
+// Disabled must NOT override the authority's PasswordChecked decision.
+func TestAuthenticate_NonAuthorityDoesNotOverrideAuthorityDecision(t *testing.T) {
+	authority := &fakeProvider{
+		name:   "authority",
+		detail: newDetail("authority", login, proto.PasswordChecked, withCredentialAuthority(true), withTranslatedUID(42)),
+	}
+	bystander := &fakeProvider{
+		name:   "bystander",
+		detail: newDetail("bystander", login, proto.Disabled, withCredentialAuthority(false), withTranslatedUID(7)),
+	}
+	m := newMerger(authority, bystander)
+	resp, err := m.Authenticate(testCtx(), &proto.IdentityRequest{Login: login})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Status != proto.PasswordChecked {
+		t.Errorf("status = %q, want %q (authority decision must stand)", resp.Status, proto.PasswordChecked)
+	}
+	if resp.Authority != "authority" {
+		t.Errorf("authority = %q, want %q", resp.Authority, "authority")
+	}
+	if resp.User.Uid == nil || *resp.User.Uid != 42 {
+		t.Errorf("uid = %v, want 42 (from authority's Translated.Uid)", resp.User.Uid)
+	}
+}
+
+// Symmetric ordering check: even when the non-authority Disabled provider is
+// walked FIRST, the later authority PasswordChecked is what wins the status.
+func TestAuthenticate_OrderIndependent_AuthorityWins(t *testing.T) {
+	bystander := &fakeProvider{
+		name:   "bystander",
+		detail: newDetail("bystander", login, proto.Disabled, withCredentialAuthority(false)),
+	}
+	authority := &fakeProvider{
+		name:   "authority",
+		detail: newDetail("authority", login, proto.PasswordChecked, withCredentialAuthority(true), withTranslatedUID(42)),
+	}
+	m := newMerger(bystander, authority)
+	resp, err := m.Authenticate(testCtx(), &proto.IdentityRequest{Login: login})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Status != proto.PasswordChecked {
+		t.Errorf("status = %q, want %q", resp.Status, proto.PasswordChecked)
+	}
+	if resp.Authority != "authority" {
+		t.Errorf("authority = %q, want %q", resp.Authority, "authority")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Priority resolution across multiple AUTHORITY providers
+// ---------------------------------------------------------------------------
+
+// Disabled (5) out-ranks PasswordChecked (4); the Disabled provider becomes
+// the authority and its uid is taken (Disabled > PasswordMissing).
+func TestAuthenticate_HigherPriorityAuthorityWins(t *testing.T) {
+	checked := &fakeProvider{
+		name:   "checked",
+		detail: newDetail("checked", login, proto.PasswordChecked, withCredentialAuthority(true), withTranslatedUID(1)),
+	}
+	disabled := &fakeProvider{
+		name:   "disabled",
+		detail: newDetail("disabled", login, proto.Disabled, withCredentialAuthority(true), withTranslatedUID(2)),
+	}
+	m := newMerger(checked, disabled)
+	resp, err := m.Authenticate(testCtx(), &proto.IdentityRequest{Login: login})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Status != proto.Disabled {
+		t.Errorf("status = %q, want %q", resp.Status, proto.Disabled)
+	}
+	if resp.Authority != "disabled" {
+		t.Errorf("authority = %q, want %q", resp.Authority, "disabled")
+	}
+	if resp.User.Uid == nil || *resp.User.Uid != 2 {
+		t.Errorf("uid = %v, want 2 (from the winning Disabled provider)", resp.User.Uid)
+	}
+}
+
+// PasswordChecked and PasswordFail tie at priority 4: strict-greater means the
+// FIRST one walked wins; the tying second provider can't displace it.
+func TestAuthenticate_TieKeepsFirstAuthority(t *testing.T) {
+	first := &fakeProvider{
+		name:   "first-fail",
+		detail: newDetail("first-fail", login, proto.PasswordFail, withCredentialAuthority(true), withTranslatedUID(11)),
+	}
+	second := &fakeProvider{
+		name:   "second-checked",
+		detail: newDetail("second-checked", login, proto.PasswordChecked, withCredentialAuthority(true), withTranslatedUID(22)),
+	}
+	m := newMerger(first, second)
+	resp, err := m.Authenticate(testCtx(), &proto.IdentityRequest{Login: login})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Status != proto.PasswordFail {
+		t.Errorf("status = %q, want %q (first writer wins on tie)", resp.Status, proto.PasswordFail)
+	}
+	if resp.Authority != "first-fail" {
+		t.Errorf("authority = %q, want %q (tie must not displace first)", resp.Authority, "first-fail")
+	}
+	if resp.User.Uid == nil || *resp.User.Uid != 11 {
+		t.Errorf("uid = %v, want 11 (from first provider)", resp.User.Uid)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Uid / Authority gating around the PasswordMissing threshold
+// ---------------------------------------------------------------------------
+
+// An authority provider whose status is exactly PasswordMissing (priority 2)
+// DOES raise response.Status above UserNotFound, but must NOT set uid/authority
+// because the gate is strictly `> priority(PasswordMissing)`.
+func TestAuthenticate_PasswordMissingRaisesStatusButNotUidOrAuthority(t *testing.T) {
+	p := &fakeProvider{
+		name:   "missing",
+		detail: newDetail("missing", login, proto.PasswordMissing, withCredentialAuthority(true), withTranslatedUID(77)),
+	}
+	m := newMerger(p)
+	resp, err := m.Authenticate(testCtx(), &proto.IdentityRequest{Login: login})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Status != proto.PasswordMissing {
+		t.Errorf("status = %q, want %q", resp.Status, proto.PasswordMissing)
+	}
+	if resp.Authority != "" {
+		t.Errorf("authority = %q, want empty (PasswordMissing must not set authority)", resp.Authority)
+	}
+	if resp.User.Uid != nil {
+		t.Errorf("uid = %v, want nil (PasswordMissing must not set uid)", *resp.User.Uid)
+	}
+}
+
+// Just above the threshold: PasswordUnchecked (priority 3) DOES set uid and
+// authority.
+func TestAuthenticate_PasswordUncheckedSetsUidAndAuthority(t *testing.T) {
+	p := &fakeProvider{
+		name:   "unchecked",
+		detail: newDetail("unchecked", login, proto.PasswordUnchecked, withCredentialAuthority(true), withTranslatedUID(55)),
+	}
+	m := newMerger(p)
+	resp, err := m.Authenticate(testCtx(), &proto.IdentityRequest{Login: login})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Status != proto.PasswordUnchecked {
+		t.Errorf("status = %q, want %q", resp.Status, proto.PasswordUnchecked)
+	}
+	if resp.Authority != "unchecked" {
+		t.Errorf("authority = %q, want %q", resp.Authority, "unchecked")
+	}
+	if resp.User.Uid == nil || *resp.User.Uid != 55 {
+		t.Errorf("uid = %v, want 55", resp.User.Uid)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Enrichment authorities are independent of CredentialAuthority
+// ---------------------------------------------------------------------------
+
+// A provider that is NOT a credential authority can still contribute groups,
+// emails, name and claims when it holds those authority flags. This proves the
+// enrichment is gated on its own flags, not on CredentialAuthority.
+func TestAuthenticate_NonCredentialProviderStillEnriches(t *testing.T) {
+	enricher := &fakeProvider{
+		name: "enricher",
+		detail: newDetail("enricher", login, proto.UserNotFound,
+			withCredentialAuthority(false),
+			withGroupAuthority(true), withTranslatedGroups("dev", "ops"),
+			withEmailAuthority(true), withUserEmails("a@x.io"),
+			withNameAuthority(true), withUserName("Alice"),
+			withClaimAuthority(true), withTranslatedClaims(map[string]interface{}{"dept": "eng"}),
+		),
+	}
+	m := newMerger(enricher)
+	resp, err := m.Authenticate(testCtx(), &proto.IdentityRequest{Login: login})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Credential decision untouched.
+	if resp.Status != proto.UserNotFound {
+		t.Errorf("status = %q, want %q", resp.Status, proto.UserNotFound)
+	}
+	if resp.Authority != "" {
+		t.Errorf("authority = %q, want empty", resp.Authority)
+	}
+	// Enrichment applied.
+	if !reflect.DeepEqual(resp.User.Groups, []string{"dev", "ops"}) {
+		t.Errorf("groups = %v, want [dev ops]", resp.User.Groups)
+	}
+	if !reflect.DeepEqual(resp.User.Emails, []string{"a@x.io"}) {
+		t.Errorf("emails = %v, want [a@x.io]", resp.User.Emails)
+	}
+	if resp.User.Name != "Alice" {
+		t.Errorf("name = %q, want Alice", resp.User.Name)
+	}
+	if got, ok := resp.User.Claims["dept"]; !ok || got != "eng" {
+		t.Errorf("claims[dept] = %v (ok=%v), want eng", got, ok)
+	}
+}
+
+// When the authority flags are OFF, nothing is enriched even though the
+// provider carries groups/emails/name/claims payloads.
+func TestAuthenticate_AuthorityFlagsOffSuppressEnrichment(t *testing.T) {
+	p := &fakeProvider{
+		name: "silent",
+		detail: newDetail("silent", login, proto.UserNotFound,
+			withCredentialAuthority(false),
+			withGroupAuthority(false), withTranslatedGroups("dev"),
+			withEmailAuthority(false), withUserEmails("a@x.io"),
+			withNameAuthority(false), withUserName("Alice"),
+			withClaimAuthority(false), withTranslatedClaims(map[string]interface{}{"dept": "eng"}),
+		),
+	}
+	m := newMerger(p)
+	resp, err := m.Authenticate(testCtx(), &proto.IdentityRequest{Login: login})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.User.Groups) != 0 {
+		t.Errorf("groups = %v, want empty", resp.User.Groups)
+	}
+	if len(resp.User.Emails) != 0 {
+		t.Errorf("emails = %v, want empty", resp.User.Emails)
+	}
+	if resp.User.Name != "" {
+		t.Errorf("name = %q, want empty", resp.User.Name)
+	}
+	if len(resp.User.Claims) != 0 {
+		t.Errorf("claims = %v, want empty", resp.User.Claims)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Group merge: dedup + sort across providers
+// ---------------------------------------------------------------------------
+
+func TestAuthenticate_GroupsDedupedAndSortedAcrossProviders(t *testing.T) {
+	p1 := &fakeProvider{
+		name:   "p1",
+		detail: newDetail("p1", login, proto.UserNotFound, withGroupAuthority(true), withTranslatedGroups("zeta", "alpha")),
+	}
+	p2 := &fakeProvider{
+		name:   "p2",
+		detail: newDetail("p2", login, proto.UserNotFound, withGroupAuthority(true), withTranslatedGroups("alpha", "mid")),
+	}
+	m := newMerger(p1, p2)
+	resp, err := m.Authenticate(testCtx(), &proto.IdentityRequest{Login: login})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"alpha", "mid", "zeta"} // deduped + lexically sorted
+	if !reflect.DeepEqual(resp.User.Groups, want) {
+		t.Errorf("groups = %v, want %v", resp.User.Groups, want)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Name merge: first non-empty writer wins
+// ---------------------------------------------------------------------------
+
+func TestAuthenticate_NameFirstWriterWins(t *testing.T) {
+	p1 := &fakeProvider{
+		name:   "p1",
+		detail: newDetail("p1", login, proto.UserNotFound, withNameAuthority(true), withUserName("First")),
+	}
+	p2 := &fakeProvider{
+		name:   "p2",
+		detail: newDetail("p2", login, proto.UserNotFound, withNameAuthority(true), withUserName("Second")),
+	}
+	m := newMerger(p1, p2)
+	resp, err := m.Authenticate(testCtx(), &proto.IdentityRequest{Login: login})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.User.Name != "First" {
+		t.Errorf("name = %q, want %q (first non-empty wins)", resp.User.Name, "First")
+	}
+}
+
+// A name-authority provider with an EMPTY name does not block a later
+// name-authority provider from filling it.
+func TestAuthenticate_EmptyNameDoesNotBlockLaterProvider(t *testing.T) {
+	p1 := &fakeProvider{
+		name:   "p1",
+		detail: newDetail("p1", login, proto.UserNotFound, withNameAuthority(true), withUserName("")),
+	}
+	p2 := &fakeProvider{
+		name:   "p2",
+		detail: newDetail("p2", login, proto.UserNotFound, withNameAuthority(true), withUserName("Second")),
+	}
+	m := newMerger(p1, p2)
+	resp, err := m.Authenticate(testCtx(), &proto.IdentityRequest{Login: login})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.User.Name != "Second" {
+		t.Errorf("name = %q, want %q", resp.User.Name, "Second")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Email merge: append-if-not-present (order preserved, dups dropped)
+// ---------------------------------------------------------------------------
+
+func TestAuthenticate_EmailsAppendedWithoutDuplicates(t *testing.T) {
+	p1 := &fakeProvider{
+		name:   "p1",
+		detail: newDetail("p1", login, proto.UserNotFound, withEmailAuthority(true), withUserEmails("a@x.io", "b@x.io")),
+	}
+	p2 := &fakeProvider{
+		name:   "p2",
+		detail: newDetail("p2", login, proto.UserNotFound, withEmailAuthority(true), withUserEmails("b@x.io", "c@x.io")),
+	}
+	m := newMerger(p1, p2)
+	resp, err := m.Authenticate(testCtx(), &proto.IdentityRequest{Login: login})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"a@x.io", "b@x.io", "c@x.io"} // order preserved, b deduped
+	if !reflect.DeepEqual(resp.User.Emails, want) {
+		t.Errorf("emails = %v, want %v", resp.User.Emails, want)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Claim merge: later provider overrides earlier (MergeMaps semantics)
+// ---------------------------------------------------------------------------
+
+// MergeMaps is called as MergeMaps(userDetail.Translated.Claims, response.User.Claims)
+// i.e. the ALREADY-ACCUMULATED claims override the incoming provider's. So for a
+// scalar key set by two providers, the EARLIER provider's value survives.
+func TestAuthenticate_ClaimsEarlierProviderWinsOnScalarConflict(t *testing.T) {
+	p1 := &fakeProvider{
+		name:   "p1",
+		detail: newDetail("p1", login, proto.UserNotFound, withClaimAuthority(true), withTranslatedClaims(map[string]interface{}{"role": "admin", "team": "blue"})),
+	}
+	p2 := &fakeProvider{
+		name:   "p2",
+		detail: newDetail("p2", login, proto.UserNotFound, withClaimAuthority(true), withTranslatedClaims(map[string]interface{}{"role": "user", "dept": "eng"})),
+	}
+	m := newMerger(p1, p2)
+	resp, err := m.Authenticate(testCtx(), &proto.IdentityRequest{Login: login})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// role: p1 set it first; accumulated value overrides p2 -> "admin".
+	if got := resp.User.Claims["role"]; got != "admin" {
+		t.Errorf("claims[role] = %v, want admin (earlier provider wins)", got)
+	}
+	// Non-conflicting keys from both providers survive.
+	if got := resp.User.Claims["team"]; got != "blue" {
+		t.Errorf("claims[team] = %v, want blue", got)
+	}
+	if got := resp.User.Claims["dept"]; got != "eng" {
+		t.Errorf("claims[dept] = %v, want eng", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Details bookkeeping
+// ---------------------------------------------------------------------------
+
+func TestAuthenticate_DetailsPopulatedInOrder(t *testing.T) {
+	d1 := newDetail("p1", login, proto.UserNotFound, withCredentialAuthority(false))
+	d2 := newDetail("p2", login, proto.PasswordChecked, withCredentialAuthority(true), withTranslatedUID(9))
+	p1 := &fakeProvider{name: "p1", detail: d1}
+	p2 := &fakeProvider{name: "p2", detail: d2}
+	m := newMerger(p1, p2)
+	resp, err := m.Authenticate(testCtx(), &proto.IdentityRequest{Login: login})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Details) != 2 {
+		t.Fatalf("details len = %d, want 2", len(resp.Details))
+	}
+	if resp.Details[0] != d1 || resp.Details[1] != d2 {
+		t.Errorf("details not stored in provider order: got [%v %v]", resp.Details[0], resp.Details[1])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Error propagation
+// ---------------------------------------------------------------------------
+
+// A provider error aborts the whole merge: nil response, the error is returned
+// verbatim, and providers AFTER the failing one are never called.
+func TestAuthenticate_ProviderErrorAbortsAndShortCircuits(t *testing.T) {
+	sentinel := errors.New("boom")
+	failing := &fakeProvider{name: "failing", err: sentinel}
+	after := &fakeProvider{
+		name:   "after",
+		detail: newDetail("after", login, proto.PasswordChecked, withCredentialAuthority(true)),
+	}
+	m := newMerger(failing, after)
+	resp, err := m.Authenticate(testCtx(), &proto.IdentityRequest{Login: login})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("err = %v, want sentinel %v", err, sentinel)
+	}
+	if resp != nil {
+		t.Errorf("response = %+v, want nil on error", resp)
+	}
+	if failing.calls != 1 {
+		t.Errorf("failing.calls = %d, want 1", failing.calls)
+	}
+	if after.calls != 0 {
+		t.Errorf("after.calls = %d, want 0 (must short-circuit on error)", after.calls)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Login propagation into the request reaching providers
+// ---------------------------------------------------------------------------
+
+// recordingProvider captures the login/password it was handed, to prove the
+// merger forwards request fields unchanged.
+type recordingProvider struct {
+	gotLogin    string
+	gotPassword string
+	detail      *proto.UserDetail
+}
+
+var _ provider.Provider = (*recordingProvider)(nil)
+
+func (r *recordingProvider) GetUserDetail(_ context.Context, l, p string) (*proto.UserDetail, error) {
+	r.gotLogin, r.gotPassword = l, p
+	return r.detail, nil
+}
+func (r *recordingProvider) GetName() string { return "recorder" }
+
+func TestAuthenticate_ForwardsLoginAndPasswordToProviders(t *testing.T) {
+	rec := &recordingProvider{
+		detail: newDetail("recorder", "bob", proto.UserNotFound, withCredentialAuthority(true)),
+	}
+	m := newMerger(rec)
+	_, err := m.Authenticate(testCtx(), &proto.IdentityRequest{Login: "bob", Password: "s3cr3t"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.gotLogin != "bob" {
+		t.Errorf("provider got login %q, want bob", rec.gotLogin)
+	}
+	if rec.gotPassword != "s3cr3t" {
+		t.Errorf("provider got password %q, want s3cr3t", rec.gotPassword)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Combined realistic scenario: authority for credentials, separate enrichers
+// ---------------------------------------------------------------------------
+
+// A typical deployment: an LDAP authority checks the password and provides uid;
+// a directory enricher (non-credential) adds groups/email/name; a claims
+// provider adds claims. Asserts all merge facets at once.
+func TestAuthenticate_CombinedRealisticMerge(t *testing.T) {
+	ldap := &fakeProvider{
+		name: "ldap",
+		detail: newDetail("ldap", login, proto.PasswordChecked,
+			withCredentialAuthority(true), withTranslatedUID(1000),
+			withGroupAuthority(true), withTranslatedGroups("ldap-users"),
+		),
+	}
+	directory := &fakeProvider{
+		name: "directory",
+		detail: newDetail("directory", login, proto.Disabled, // higher priority but NOT authority
+			withCredentialAuthority(false),
+			withGroupAuthority(true), withTranslatedGroups("staff", "ldap-users"),
+			withEmailAuthority(true), withUserEmails("alice@corp.io"),
+			withNameAuthority(true), withUserName("Alice Liddell"),
+		),
+	}
+	claims := &fakeProvider{
+		name: "claims",
+		detail: newDetail("claims", login, proto.UserNotFound,
+			withCredentialAuthority(false),
+			withClaimAuthority(true), withTranslatedClaims(map[string]interface{}{"tier": "gold"}),
+		),
+	}
+	m := newMerger(ldap, directory, claims)
+	resp, err := m.Authenticate(testCtx(), &proto.IdentityRequest{Login: login, Password: "pw"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Credential decision comes from ldap; directory's Disabled is ignored.
+	if resp.Status != proto.PasswordChecked {
+		t.Errorf("status = %q, want %q", resp.Status, proto.PasswordChecked)
+	}
+	if resp.Authority != "ldap" {
+		t.Errorf("authority = %q, want ldap", resp.Authority)
+	}
+	if resp.User.Uid == nil || *resp.User.Uid != 1000 {
+		t.Errorf("uid = %v, want 1000", resp.User.Uid)
+	}
+	// Groups merged from ldap + directory, deduped + sorted.
+	wantGroups := []string{"ldap-users", "staff"}
+	if !reflect.DeepEqual(resp.User.Groups, wantGroups) {
+		t.Errorf("groups = %v, want %v", resp.User.Groups, wantGroups)
+	}
+	if !reflect.DeepEqual(resp.User.Emails, []string{"alice@corp.io"}) {
+		t.Errorf("emails = %v, want [alice@corp.io]", resp.User.Emails)
+	}
+	if resp.User.Name != "Alice Liddell" {
+		t.Errorf("name = %q, want Alice Liddell", resp.User.Name)
+	}
+	if got := resp.User.Claims["tier"]; got != "gold" {
+		t.Errorf("claims[tier] = %v, want gold", got)
+	}
+	if len(resp.Details) != 3 {
+		t.Errorf("details len = %d, want 3", len(resp.Details))
+	}
+}

--- a/cmd/merger/authenticator/priority_test.go
+++ b/cmd/merger/authenticator/priority_test.go
@@ -1,0 +1,86 @@
+/*
+Copyright (c) 2025 Kubotal.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package authenticator
+
+import (
+	"kubauth/internal/proto"
+	"testing"
+)
+
+// The merger walks providers and chooses the response Status whose
+// `priority(...)` is highest. The ordering is the contract that lets a
+// single LDAP "Disabled" override a UCRD "PasswordChecked", and so on.
+// If anyone reorders priorityByStatus, this test fails.
+func TestPriorityOrdering(t *testing.T) {
+	// Strict-greater-than chain: each step MUST out-rank the previous.
+	chain := []proto.Status{
+		proto.Undefined,
+		proto.UserNotFound,
+		proto.PasswordMissing,
+		proto.PasswordUnchecked,
+		proto.PasswordChecked, // tied with PasswordFail (both 4)
+		proto.Disabled,
+	}
+	for i := 1; i < len(chain); i++ {
+		if priority(chain[i]) <= priority(chain[i-1]) {
+			t.Errorf("priority(%s)=%d should be > priority(%s)=%d",
+				chain[i], priority(chain[i]),
+				chain[i-1], priority(chain[i-1]))
+		}
+	}
+}
+
+func TestPriority_PasswordCheckedAndFailAreEqual(t *testing.T) {
+	// Documented tie: PasswordChecked and PasswordFail share priority.
+	// The merger relies on this — a provider that says "fail" doesn't
+	// get out-ranked by another saying "checked", and vice versa.
+	if priority(proto.PasswordChecked) != priority(proto.PasswordFail) {
+		t.Errorf("PasswordChecked and PasswordFail must tie: got %d vs %d",
+			priority(proto.PasswordChecked), priority(proto.PasswordFail))
+	}
+}
+
+func TestPriority_DisabledOutranksEverything(t *testing.T) {
+	disabled := priority(proto.Disabled)
+	for _, s := range []proto.Status{
+		proto.Undefined,
+		proto.UserNotFound,
+		proto.PasswordMissing,
+		proto.PasswordUnchecked,
+		proto.PasswordChecked,
+		proto.PasswordFail,
+	} {
+		if priority(s) >= disabled {
+			t.Errorf("Disabled (%d) must out-rank %s (%d)", disabled, s, priority(s))
+		}
+	}
+}
+
+func TestPriority_UndefinedIsLowest(t *testing.T) {
+	undef := priority(proto.Undefined)
+	for _, s := range []proto.Status{
+		proto.UserNotFound,
+		proto.PasswordMissing,
+		proto.PasswordUnchecked,
+		proto.PasswordChecked,
+		proto.PasswordFail,
+		proto.Disabled,
+	} {
+		if priority(s) <= undef {
+			t.Errorf("Undefined (%d) must be lowest, but %s = %d", undef, s, priority(s))
+		}
+	}
+}
+
+func TestPriority_UnknownStatusReturnsZero(t *testing.T) {
+	// Unmapped string → zero value (Go map default). This is the
+	// degraded but non-panicking behaviour callers rely on.
+	if got := priority(proto.Status("not-a-real-status")); got != 0 {
+		t.Errorf("priority of unknown status should be 0, got %d", got)
+	}
+}

--- a/cmd/merger/provider/provider_test.go
+++ b/cmd/merger/provider/provider_test.go
@@ -1,0 +1,169 @@
+/*
+Copyright (c) 2025 Kubotal.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"testing"
+
+	"kubauth/cmd/merger/config"
+	"kubauth/internal/httpclient"
+	"kubauth/internal/proto"
+
+	"github.com/go-logr/logr"
+)
+
+func testCtx() context.Context {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	return logr.NewContextWithSlogLogger(context.Background(), logger)
+}
+
+// newProvider wires a provider to an httptest server running handler h, after
+// pointing cfg.HttpConfig at it. cfg is mutated by New (defaults applied).
+func newProvider(t *testing.T, cfg *config.IdProviderConfig, h http.HandlerFunc) Provider {
+	t.Helper()
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+	cfg.HttpConfig.BaseURL = srv.URL
+	p, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return p
+}
+
+func respHandler(t *testing.T, resp proto.IdentityResponse) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Errorf("encode response: %v", err)
+		}
+	}
+}
+
+func errHandler(w http.ResponseWriter, _ *http.Request) {
+	http.Error(w, "boom", http.StatusInternalServerError)
+}
+
+func TestNew_AppliesDefaults(t *testing.T) {
+	cfg := &config.IdProviderConfig{Name: "p1", HttpConfig: httpclient.Config{BaseURL: "http://example.com"}}
+	if _, err := New(cfg); err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if cfg.GroupPattern != "%s" {
+		t.Errorf("GroupPattern default = %q, want %q", cfg.GroupPattern, "%s")
+	}
+	if cfg.ClaimPattern != "%s" {
+		t.Errorf("ClaimPattern default = %q, want %q", cfg.ClaimPattern, "%s")
+	}
+	for name, b := range map[string]*bool{
+		"Credential": cfg.CredentialAuthority,
+		"Group":      cfg.GroupAuthority,
+		"Claim":      cfg.ClaimAuthority,
+		"Name":       cfg.NameAuthority,
+		"Email":      cfg.EmailAuthority,
+		"Critical":   cfg.Critical,
+	} {
+		if b == nil || !*b {
+			t.Errorf("%sAuthority default = %v, want true", name, b)
+		}
+	}
+}
+
+func TestNew_InvalidURL(t *testing.T) {
+	cfg := &config.IdProviderConfig{Name: "p", HttpConfig: httpclient.Config{BaseURL: "ftp://example.com"}}
+	if _, err := New(cfg); err == nil {
+		t.Fatal("expected error for non-http(s) URL scheme, got nil")
+	}
+}
+
+func TestGetUserDetail_SuccessTranslatesGroupsClaimsUid(t *testing.T) {
+	uid := 1000
+	resp := proto.IdentityResponse{
+		Status: proto.PasswordChecked,
+		User: proto.User{
+			Login:  "alice",
+			Uid:    &uid,
+			Groups: []string{"admin", "dev"},
+			Claims: map[string]interface{}{"team": "blue"},
+		},
+	}
+	cfg := &config.IdProviderConfig{Name: "ldap", GroupPattern: "ext:%s", ClaimPattern: "c_%s", UidOffset: 10000}
+	ud, err := newProvider(t, cfg, respHandler(t, resp)).GetUserDetail(testCtx(), "alice", "pw")
+	if err != nil {
+		t.Fatalf("GetUserDetail: %v", err)
+	}
+	if ud.Status != proto.PasswordChecked {
+		t.Errorf("status = %q, want %q", ud.Status, proto.PasswordChecked)
+	}
+	if got, want := ud.Translated.Groups, []string{"ext:admin", "ext:dev"}; !slices.Equal(got, want) {
+		t.Errorf("translated groups = %v, want %v (GroupPattern applied)", got, want)
+	}
+	if ud.Translated.Claims["c_team"] != "blue" {
+		t.Errorf("translated claims[c_team] = %v, want %q (ClaimPattern applied to key)", ud.Translated.Claims["c_team"], "blue")
+	}
+	if ud.Translated.Uid == nil || *ud.Translated.Uid != 11000 {
+		t.Errorf("translated uid = %v, want 11000 (uid 1000 + offset 10000)", ud.Translated.Uid)
+	}
+	if ud.Provider.Name != "ldap" {
+		t.Errorf("provider name = %q, want %q", ud.Provider.Name, "ldap")
+	}
+	if ud.User.Login != "alice" {
+		t.Errorf("user passed through = %q, want alice", ud.User.Login)
+	}
+}
+
+func TestGetUserDetail_CriticalFailureReturnsError(t *testing.T) {
+	// Critical defaults to true.
+	cfg := &config.IdProviderConfig{Name: "p"}
+	ud, err := newProvider(t, cfg, errHandler).GetUserDetail(testCtx(), "x", "pw")
+	if err == nil {
+		t.Fatal("a critical provider must propagate the failure as an error")
+	}
+	if ud != nil {
+		t.Errorf("want nil userDetail on critical failure, got %+v", ud)
+	}
+}
+
+func TestGetUserDetail_NonCriticalFailureFailsSoft(t *testing.T) {
+	no := false
+	cfg := &config.IdProviderConfig{Name: "p", Critical: &no}
+	ud, err := newProvider(t, cfg, errHandler).GetUserDetail(testCtx(), "ghost", "pw")
+	if err != nil {
+		t.Fatalf("a non-critical provider must not error on failure: %v", err)
+	}
+	if ud == nil {
+		t.Fatal("non-critical failure must return a placeholder userDetail, got nil")
+	}
+	if ud.Status != proto.Undefined {
+		t.Errorf("status = %q, want %q", ud.Status, proto.Undefined)
+	}
+	if ud.User.Login != "ghost" {
+		t.Errorf("user = %q, want InitUser(ghost)", ud.User.Login)
+	}
+	if ud.Provider.Name != "p" {
+		t.Errorf("provider name = %q, want p", ud.Provider.Name)
+	}
+}
+
+func TestGetName(t *testing.T) {
+	cfg := &config.IdProviderConfig{Name: "my-idp", HttpConfig: httpclient.Config{BaseURL: "http://example.com"}}
+	p, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if p.GetName() != "my-idp" {
+		t.Errorf("GetName() = %q, want my-idp", p.GetName())
+	}
+}

--- a/cmd/oidc/authenticator/httpprovider/httpprovider.go
+++ b/cmd/oidc/authenticator/httpprovider/httpprovider.go
@@ -129,7 +129,7 @@ func (u *httpProvider) Identify(ctx context.Context, login string, password stri
 }
 
 func getStringArrayInMap(m map[string]interface{}, key string) ([]string, error) {
-	if entry, exists := m["key"]; exists && entry != nil {
+	if entry, exists := m[key]; exists && entry != nil {
 		// Try to convert claims["groups"] to []string
 		switch v := entry.(type) {
 		case []string:

--- a/cmd/oidc/authenticator/httpprovider/httpprovider_test.go
+++ b/cmd/oidc/authenticator/httpprovider/httpprovider_test.go
@@ -1,0 +1,245 @@
+/*
+Copyright (c) 2025 Kubotal.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package httpprovider
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"testing"
+
+	"kubauth/cmd/oidc/authenticator"
+	"kubauth/internal/httpclient"
+	"kubauth/internal/proto"
+
+	"github.com/go-logr/logr"
+)
+
+// testCtx returns a context carrying a discard slog logger. Identify calls
+// logr.FromContextAsSlogLogger(ctx) and would panic on a bare context.
+func testCtx() context.Context {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	return logr.NewContextWithSlogLogger(context.Background(), logger)
+}
+
+// newProvider stands up an httptest server answering the v1/identity exchange
+// with resp, and returns a provider wired to it through the real http client.
+func newProvider(t *testing.T, resp proto.IdentityResponse) authenticator.OidcAuthenticator {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %q, want GET", r.Method)
+		}
+		if r.URL.Path != "/v1/identity" {
+			t.Errorf("path = %q, want /v1/identity", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Errorf("encode response: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	p, err := New(&httpclient.Config{BaseURL: srv.URL})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return p
+}
+
+// toStringSlice normalizes a claim value (either []string after enrichment or
+// []interface{} straight from JSON) into a []string for comparison.
+func toStringSlice(t *testing.T, v interface{}) []string {
+	t.Helper()
+	switch s := v.(type) {
+	case nil:
+		return nil
+	case []string:
+		return s
+	case []interface{}:
+		out := make([]string, 0, len(s))
+		for _, e := range s {
+			str, ok := e.(string)
+			if !ok {
+				t.Fatalf("claim element %v (%T) is not a string", e, e)
+			}
+			out = append(out, str)
+		}
+		return out
+	default:
+		t.Fatalf("claim value %v (%T) is not a string slice", v, v)
+		return nil
+	}
+}
+
+// TestIdentify_FederatesGroupsAndEmailsFromClaims is the regression test for the
+// claims-federation bug: groups/emails carried *inside* the claims map must be
+// merged with the dedicated User.Groups / User.Emails fields, not dropped.
+func TestIdentify_FederatesGroupsAndEmailsFromClaims(t *testing.T) {
+	resp := proto.IdentityResponse{
+		Status: proto.PasswordChecked,
+		User: proto.User{
+			Login:  "alice",
+			Groups: []string{"dedicated-grp"},
+			Emails: []string{"alice@corp.io"},
+			Claims: map[string]interface{}{
+				"groups": []string{"claim-grp"},
+				"emails": []string{"alice-alt@corp.io"},
+			},
+		},
+	}
+	user, status, err := newProvider(t, resp).Identify(testCtx(), "alice", "secret")
+	if err != nil {
+		t.Fatalf("Identify: %v", err)
+	}
+	if status != proto.PasswordChecked {
+		t.Errorf("status = %q, want %q", status, proto.PasswordChecked)
+	}
+	// DedupAndSort => sorted ascending.
+	if got, want := toStringSlice(t, user.Claims["groups"]), []string{"claim-grp", "dedicated-grp"}; !slices.Equal(got, want) {
+		t.Errorf("claims[groups] = %v, want %v (group carried in claims must be federated)", got, want)
+	}
+	// AppendIfNotPresent => order preserved (dedicated first, then claim-carried).
+	if got, want := toStringSlice(t, user.Claims["emails"]), []string{"alice@corp.io", "alice-alt@corp.io"}; !slices.Equal(got, want) {
+		t.Errorf("claims[emails] = %v, want %v (email carried in claims must be federated)", got, want)
+	}
+}
+
+func TestIdentify_EnrichesNameUidAuthorityEmail(t *testing.T) {
+	uid := 4242
+	resp := proto.IdentityResponse{
+		Status:    proto.PasswordChecked,
+		Authority: "corp-idp",
+		User: proto.User{
+			Login:  "bob",
+			Name:   "Bob Smith",
+			Uid:    &uid,
+			Emails: []string{"bob@corp.io", "bob2@corp.io"},
+			Claims: map[string]interface{}{},
+		},
+	}
+	user, _, err := newProvider(t, resp).Identify(testCtx(), "bob", "pw")
+	if err != nil {
+		t.Fatalf("Identify: %v", err)
+	}
+	if user.FullName != "Bob Smith" {
+		t.Errorf("FullName = %q, want %q", user.FullName, "Bob Smith")
+	}
+	if user.Claims["name"] != "Bob Smith" {
+		t.Errorf("claims[name] = %v, want %q", user.Claims["name"], "Bob Smith")
+	}
+	if user.Claims["authority"] != "corp-idp" {
+		t.Errorf("claims[authority] = %v, want %q", user.Claims["authority"], "corp-idp")
+	}
+	if uidv, ok := user.Claims["uid"].(int); !ok || uidv != 4242 {
+		t.Errorf("claims[uid] = %v (%T), want int 4242", user.Claims["uid"], user.Claims["uid"])
+	}
+	if user.Claims["email"] != "bob@corp.io" {
+		t.Errorf("claims[email] = %v, want first email %q", user.Claims["email"], "bob@corp.io")
+	}
+	if got, want := toStringSlice(t, user.Claims["emails"]), []string{"bob@corp.io", "bob2@corp.io"}; !slices.Equal(got, want) {
+		t.Errorf("claims[emails] = %v, want %v", got, want)
+	}
+}
+
+func TestIdentify_PropagatesStatus(t *testing.T) {
+	resp := proto.IdentityResponse{
+		Status: proto.PasswordFail,
+		User:   proto.User{Login: "carol", Claims: map[string]interface{}{}},
+	}
+	user, status, err := newProvider(t, resp).Identify(testCtx(), "carol", "bad")
+	if err != nil {
+		t.Fatalf("Identify: %v", err)
+	}
+	if status != proto.PasswordFail {
+		t.Errorf("status = %q, want %q", status, proto.PasswordFail)
+	}
+	if user == nil || user.Login != "carol" {
+		t.Errorf("user = %+v, want login carol regardless of password status", user)
+	}
+}
+
+func TestIdentify_ErrorOnNonArrayClaim(t *testing.T) {
+	resp := proto.IdentityResponse{
+		Status: proto.PasswordChecked,
+		User:   proto.User{Login: "erin", Claims: map[string]interface{}{"groups": 123}},
+	}
+	if _, _, err := newProvider(t, resp).Identify(testCtx(), "erin", "pw"); err == nil {
+		t.Fatal("expected error when claims[groups] is not a string array, got nil")
+	}
+}
+
+func TestIdentify_SingleStringClaimGroup(t *testing.T) {
+	resp := proto.IdentityResponse{
+		Status: proto.PasswordChecked,
+		User:   proto.User{Login: "frank", Claims: map[string]interface{}{"groups": "solo"}},
+	}
+	user, _, err := newProvider(t, resp).Identify(testCtx(), "frank", "pw")
+	if err != nil {
+		t.Fatalf("Identify: %v", err)
+	}
+	if got, want := toStringSlice(t, user.Claims["groups"]), []string{"solo"}; !slices.Equal(got, want) {
+		t.Errorf("claims[groups] = %v, want %v (a single string claim becomes a one-element group)", got, want)
+	}
+}
+
+func TestAuthenticate_ReturnsUserWhenPasswordChecked(t *testing.T) {
+	resp := proto.IdentityResponse{
+		Status: proto.PasswordChecked,
+		User:   proto.User{Login: "dave", Claims: map[string]interface{}{}},
+	}
+	user, err := newProvider(t, resp).Authenticate(testCtx(), "dave", "pw")
+	if err != nil {
+		t.Fatalf("Authenticate: %v", err)
+	}
+	if user == nil || user.Login != "dave" {
+		t.Errorf("user = %+v, want authenticated user dave", user)
+	}
+}
+
+func TestAuthenticate_NilWhenNotPasswordChecked(t *testing.T) {
+	for _, st := range []proto.Status{proto.PasswordFail, proto.PasswordUnchecked, proto.UserNotFound, proto.Disabled} {
+		resp := proto.IdentityResponse{
+			Status: st,
+			User:   proto.User{Login: "x", Claims: map[string]interface{}{}},
+		}
+		user, err := newProvider(t, resp).Authenticate(testCtx(), "x", "pw")
+		if err != nil {
+			t.Fatalf("status %q: Authenticate: %v", st, err)
+		}
+		if user != nil {
+			t.Errorf("status %q: user = %+v, want nil (not authenticated)", st, user)
+		}
+	}
+}
+
+func TestIdentifyAndAuthenticate_PropagateHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+	p, err := New(&httpclient.Config{BaseURL: srv.URL})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if _, _, err := p.Identify(testCtx(), "x", "pw"); err == nil {
+		t.Error("Identify: expected error on HTTP 500, got nil")
+	}
+	if _, err := p.Authenticate(testCtx(), "x", "pw"); err == nil {
+		t.Error("Authenticate: expected error on HTTP 500, got nil")
+	}
+}
+
+func TestNew_InvalidURL(t *testing.T) {
+	if _, err := New(&httpclient.Config{BaseURL: "ftp://example.com"}); err == nil {
+		t.Fatal("expected error for non-http(s) URL scheme, got nil")
+	}
+}

--- a/cmd/oidc/fositepatch/compose2_test.go
+++ b/cmd/oidc/fositepatch/compose2_test.go
@@ -1,0 +1,176 @@
+/*
+Copyright (c) 2025 Kubotal.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package fositepatch
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"kubauth/api/kubauth/v1alpha1"
+	"kubauth/cmd/oidc/oidcstorage"
+
+	"github.com/ory/hydra/v2/fosite"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// --- Smoke: provider construction ----------------------------------------
+
+func TestComposeAllEnabled_ReturnsProvider_HMAC(t *testing.T) {
+	store := newTestStore(t, &fakeAuthenticator{}, true)
+	p := ComposeAllEnabled(newTestConfig(), store, newTestKey(t), false)
+	if p == nil {
+		t.Fatal("ComposeAllEnabled returned nil provider (HMAC access tokens)")
+	}
+}
+
+func TestComposeAllEnabled_ReturnsProvider_JWT(t *testing.T) {
+	store := newTestStore(t, &fakeAuthenticator{}, true)
+	p := ComposeAllEnabled(newTestConfig(), store, newTestKey(t), true)
+	if p == nil {
+		t.Fatal("ComposeAllEnabled returned nil provider (JWT access tokens)")
+	}
+}
+
+// registerConfidentialClient stores a password-grant client whose secret
+// hashes to `secret` under the config's hasher, so it can authenticate via
+// client_secret_post against the composed provider.
+func registerConfidentialClient(t *testing.T, store *oidcstorage.MemoryStore, config *fosite.Config, clientID, secret string, scopes []string) {
+	t.Helper()
+	hashed, err := config.GetSecretsHasher(testContext()).Hash(testContext(), []byte(secret))
+	if err != nil {
+		t.Fatalf("failed to hash client secret: %v", err)
+	}
+	cli := &v1alpha1.OidcClient{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "kubauth-system", Name: clientID},
+		Spec: v1alpha1.OidcClientSpec{
+			RedirectURIs:  []string{"https://app/callback"},
+			GrantTypes:    []string{"password"},
+			ResponseTypes: []string{"code"},
+			Scopes:        scopes,
+			Audiences:     []string{clientID},
+			Public:        false,
+		},
+	}
+	kc := oidcstorage.NewKubauthClient(cli, clientID, [][]byte{hashed})
+	if err := store.SetClient(testContext(), kc); err != nil {
+		t.Fatalf("failed to register client: %v", err)
+	}
+}
+
+// tokenPOST builds a POST request to the token endpoint with a form body,
+// exactly as a client would send it.
+func tokenPOST(form url.Values) *http.Request {
+	r := httptest.NewRequest(http.MethodPost, "https://issuer.example.com/oauth2/token", strings.NewReader(form.Encode()))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	return r
+}
+
+// TestComposeAllEnabled_ROPCFactoryIsWired drives a full password-grant
+// token request through the composed provider. If
+// OAuth2ResourceOwnerPasswordCredentialsFactory were not registered by
+// ComposeAllEnabled, NewAccessRequest would fail to find a handler and
+// return invalid_request. A successful access+id token proves the ROPC
+// handler is composed in and reachable end-to-end.
+func TestComposeAllEnabled_ROPCFactoryIsWired(t *testing.T) {
+	config := newTestConfig()
+	store := newTestStore(t, &fakeAuthenticator{}, true)
+	registerConfidentialClient(t, store, config, "ropc-app", "s3cret", []string{"openid", "profile"})
+
+	provider := ComposeAllEnabled(config, store, newTestKey(t), false)
+	ctx := testContext()
+
+	form := url.Values{}
+	form.Set("grant_type", "password")
+	form.Set("client_id", "ropc-app")
+	form.Set("client_secret", "s3cret")
+	form.Set("username", "alice")
+	form.Set("password", "pw")
+	form.Set("scope", "openid profile")
+
+	ar, err := provider.NewAccessRequest(ctx, tokenPOST(form), &OIDCSession{})
+	if err != nil {
+		t.Fatalf("NewAccessRequest failed (ROPC handler likely not composed): %v", err)
+	}
+	if !ar.GetGrantTypes().ExactOne("password") {
+		t.Fatalf("expected password grant, got %v", ar.GetGrantTypes())
+	}
+	// HandleScopes inside the ROPC handler must have granted requested scopes.
+	for _, want := range []string{"openid", "profile"} {
+		if !ar.GetGrantedScopes().Has(want) {
+			t.Errorf("expected scope %q granted by ROPC handler, granted=%v", want, ar.GetGrantedScopes())
+		}
+	}
+
+	resp, err := provider.NewAccessResponse(ctx, ar)
+	if err != nil {
+		t.Fatalf("NewAccessResponse failed: %v", err)
+	}
+	if resp.GetAccessToken() == "" {
+		t.Error("composed provider should issue an access token for ROPC")
+	}
+	if resp.GetExtra("id_token") == nil {
+		t.Error("composed provider should issue an id_token when openid is granted")
+	}
+}
+
+// A wrong client secret must be rejected by the composed provider's client
+// authentication, proving auth is actually enforced (not bypassed).
+func TestComposeAllEnabled_ROPCRejectsBadClientSecret(t *testing.T) {
+	config := newTestConfig()
+	store := newTestStore(t, &fakeAuthenticator{}, true)
+	registerConfidentialClient(t, store, config, "ropc-app", "right-secret", []string{"openid"})
+
+	provider := ComposeAllEnabled(config, store, newTestKey(t), false)
+
+	form := url.Values{}
+	form.Set("grant_type", "password")
+	form.Set("client_id", "ropc-app")
+	form.Set("client_secret", "wrong-secret")
+	form.Set("username", "alice")
+	form.Set("password", "pw")
+	form.Set("scope", "openid")
+
+	_, err := provider.NewAccessRequest(testContext(), tokenPOST(form), &OIDCSession{})
+	if err == nil {
+		t.Fatal("expected client authentication to fail with wrong secret")
+	}
+	rfc := fosite.ErrorToRFC6749Error(err)
+	if rfc.ErrorField != fosite.ErrInvalidClient.ErrorField {
+		t.Fatalf("expected invalid_client, got %v (%v)", rfc.ErrorField, err)
+	}
+}
+
+// When the server disables the password grant, the composed provider must
+// reject ROPC requests even from an otherwise-valid client.
+func TestComposeAllEnabled_ROPCRejectedWhenPasswordGrantDisabled(t *testing.T) {
+	config := newTestConfig()
+	store := newTestStore(t, &fakeAuthenticator{}, false) // password grant OFF
+	registerConfidentialClient(t, store, config, "ropc-app", "s3cret", []string{"openid"})
+
+	provider := ComposeAllEnabled(config, store, newTestKey(t), false)
+
+	form := url.Values{}
+	form.Set("grant_type", "password")
+	form.Set("client_id", "ropc-app")
+	form.Set("client_secret", "s3cret")
+	form.Set("username", "alice")
+	form.Set("password", "pw")
+	form.Set("scope", "openid")
+
+	_, err := provider.NewAccessRequest(testContext(), tokenPOST(form), &OIDCSession{})
+	if err == nil {
+		t.Fatal("expected ROPC to be rejected when password grant disabled")
+	}
+	rfc := fosite.ErrorToRFC6749Error(err)
+	if rfc.ErrorField != fosite.ErrRequestForbidden.ErrorField {
+		t.Fatalf("expected request_forbidden, got %v (%v)", rfc.ErrorField, err)
+	}
+}

--- a/cmd/oidc/fositepatch/flow_resource_owner_test.go
+++ b/cmd/oidc/fositepatch/flow_resource_owner_test.go
@@ -1,0 +1,514 @@
+/*
+Copyright (c) 2025 Kubotal.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package fositepatch
+
+import (
+	"context"
+	"errors"
+	"net/url"
+	"testing"
+
+	"kubauth/cmd/oidc/authenticator"
+	"kubauth/cmd/oidc/oidcstorage"
+
+	"github.com/ory/hydra/v2/fosite"
+	"github.com/ory/hydra/v2/fosite/compose"
+	"github.com/ory/hydra/v2/fosite/token/jwt"
+)
+
+// newROPCHandler builds a ResourceOwnerPasswordCredentialsGrantHandler the
+// same way ComposeAllEnabled does: via the production factory wired to a
+// real compose.CommonStrategy (HMAC core + OIDC JWT). This means
+// PopulateTokenEndpointResponse exercises real token generation, not a mock.
+func newROPCHandler(t *testing.T, store *oidcstorage.MemoryStore, config *fosite.Config) *ResourceOwnerPasswordCredentialsGrantHandler {
+	t.Helper()
+	key := newTestKey(t)
+	keyGetter := func(context.Context) (interface{}, error) { return key, nil }
+	strategy := &compose.CommonStrategy{
+		CoreStrategy:      compose.NewOAuth2HMACStrategy(config),
+		OIDCTokenStrategy: compose.NewOpenIDConnectStrategy(keyGetter, config),
+		Signer:            &jwt.DefaultSigner{GetPrivateKey: keyGetter},
+	}
+	h, ok := OAuth2ResourceOwnerPasswordCredentialsFactory(config, store, strategy).(*ResourceOwnerPasswordCredentialsGrantHandler)
+	if !ok {
+		t.Fatal("factory did not return *ResourceOwnerPasswordCredentialsGrantHandler")
+	}
+	return h
+}
+
+// ropcRequestOpts configures a ROPC access request.
+type ropcRequestOpts struct {
+	grantType      string // defaults to "password"
+	client         fosite.Client
+	requestedScope []string
+	requestedAud   []string
+	form           url.Values
+}
+
+// newROPCRequest builds a real *fosite.AccessRequest for the token endpoint.
+func newROPCRequest(o ropcRequestOpts) *fosite.AccessRequest {
+	ar := fosite.NewAccessRequest(&OIDCSession{})
+	gt := o.grantType
+	if gt == "" {
+		gt = "password"
+	}
+	ar.GrantTypes = fosite.Arguments{gt}
+	ar.Client = o.client
+	ar.RequestedScope = fosite.Arguments(o.requestedScope)
+	ar.RequestedAudience = fosite.Arguments(o.requestedAud)
+	if o.form != nil {
+		ar.Form = o.form
+	}
+	return ar
+}
+
+// credForm builds a username/password (+ client_id) POST body.
+func credForm(username, password, clientID string) url.Values {
+	f := url.Values{}
+	f.Set("username", username)
+	f.Set("password", password)
+	if clientID != "" {
+		f.Set("client_id", clientID)
+	}
+	return f
+}
+
+// passwordClient is a client allowed to use the password grant.
+func passwordClient(scopes, audiences []string) oidcstorage.KubauthClient {
+	return newTestClient(testClientOpts{
+		clientID:   "ropc-client",
+		scopes:     scopes,
+		audiences:  audiences,
+		grantTypes: []string{"password"},
+	})
+}
+
+// --- CanHandleTokenEndpointRequest / GetName -----------------------------
+
+func TestROPC_CanHandle_OnlyExactPasswordGrant(t *testing.T) {
+	h := &ResourceOwnerPasswordCredentialsGrantHandler{}
+	ctx := testContext()
+
+	if !h.CanHandleTokenEndpointRequest(ctx, newROPCRequest(ropcRequestOpts{grantType: "password"})) {
+		t.Error("should handle exact 'password' grant")
+	}
+	if h.CanHandleTokenEndpointRequest(ctx, newROPCRequest(ropcRequestOpts{grantType: "authorization_code"})) {
+		t.Error("must not handle 'authorization_code' grant")
+	}
+	// More than one grant type is not an exact match.
+	multi := fosite.NewAccessRequest(&OIDCSession{})
+	multi.GrantTypes = fosite.Arguments{"password", "refresh_token"}
+	if h.CanHandleTokenEndpointRequest(ctx, multi) {
+		t.Error("must not handle when password is combined with another grant")
+	}
+}
+
+func TestROPC_GetName(t *testing.T) {
+	h := &ResourceOwnerPasswordCredentialsGrantHandler{}
+	if got := h.GetName(); got != "ResourceOwnerPasswordCredentialsGrantHandler" {
+		t.Errorf("unexpected handler name %q", got)
+	}
+}
+
+func TestROPC_CanSkipClientAuth_IsFalse(t *testing.T) {
+	h := &ResourceOwnerPasswordCredentialsGrantHandler{}
+	if h.CanSkipClientAuth(testContext(), nil) {
+		t.Error("ROPC must always require client authentication")
+	}
+}
+
+// --- HandleTokenEndpointRequest: rejection paths -------------------------
+
+func TestROPC_Handle_UnknownGrantRejected(t *testing.T) {
+	store := newTestStore(t, &fakeAuthenticator{}, true)
+	h := newROPCHandler(t, store, newTestConfig())
+
+	req := newROPCRequest(ropcRequestOpts{
+		grantType: "authorization_code",
+		client:    passwordClient([]string{"openid"}, nil),
+		form:      credForm("alice", "pw", "ropc-client"),
+	})
+	err := h.HandleTokenEndpointRequest(testContext(), req)
+	if !errors.Is(err, fosite.ErrUnknownRequest) {
+		t.Fatalf("expected ErrUnknownRequest, got %v", err)
+	}
+}
+
+func TestROPC_Handle_PasswordGrantDisabledByServer(t *testing.T) {
+	// AllowPasswordGrant=false even though the client lists the grant.
+	store := newTestStore(t, &fakeAuthenticator{}, false)
+	h := newROPCHandler(t, store, newTestConfig())
+
+	req := newROPCRequest(ropcRequestOpts{
+		client: passwordClient([]string{"openid"}, nil),
+		form:   credForm("alice", "pw", "ropc-client"),
+	})
+	err := h.HandleTokenEndpointRequest(testContext(), req)
+	rfc := fosite.ErrorToRFC6749Error(err)
+	if rfc.ErrorField != fosite.ErrRequestForbidden.ErrorField {
+		t.Fatalf("expected request_forbidden, got %v (%v)", rfc.ErrorField, err)
+	}
+}
+
+func TestROPC_Handle_ClientNotAllowedPasswordGrant(t *testing.T) {
+	store := newTestStore(t, &fakeAuthenticator{}, true)
+	h := newROPCHandler(t, store, newTestConfig())
+
+	// Client without "password" in its grant types.
+	client := newTestClient(testClientOpts{
+		clientID:   "ropc-client",
+		scopes:     []string{"openid"},
+		grantTypes: []string{"authorization_code"},
+	})
+	req := newROPCRequest(ropcRequestOpts{
+		client: client,
+		form:   credForm("alice", "pw", "ropc-client"),
+	})
+	err := h.HandleTokenEndpointRequest(testContext(), req)
+	rfc := fosite.ErrorToRFC6749Error(err)
+	if rfc.ErrorField != fosite.ErrUnauthorizedClient.ErrorField {
+		t.Fatalf("expected unauthorized_client, got %v (%v)", rfc.ErrorField, err)
+	}
+}
+
+func TestROPC_Handle_RequestedScopeOutsideClientRejected(t *testing.T) {
+	store := newTestStore(t, &fakeAuthenticator{}, true)
+	h := newROPCHandler(t, store, newTestConfig())
+
+	req := newROPCRequest(ropcRequestOpts{
+		client:         passwordClient([]string{"openid"}, nil),
+		requestedScope: []string{"openid", "admin"}, // admin not allowed
+		form:           credForm("alice", "pw", "ropc-client"),
+	})
+	err := h.HandleTokenEndpointRequest(testContext(), req)
+	rfc := fosite.ErrorToRFC6749Error(err)
+	if rfc.ErrorField != fosite.ErrInvalidScope.ErrorField {
+		t.Fatalf("expected invalid_scope, got %v (%v)", rfc.ErrorField, err)
+	}
+}
+
+func TestROPC_Handle_RequestedAudienceOutsideClientRejected(t *testing.T) {
+	store := newTestStore(t, &fakeAuthenticator{}, true)
+	h := newROPCHandler(t, store, newTestConfig())
+
+	// Client audience is only its own id (+ auto client_id). Request a
+	// foreign audience -> AudienceStrategy rejects it.
+	req := newROPCRequest(ropcRequestOpts{
+		client:       passwordClient([]string{"openid"}, []string{"ropc-client"}),
+		requestedAud: []string{"https://foreign-api"},
+		form:         credForm("alice", "pw", "ropc-client"),
+	})
+	err := h.HandleTokenEndpointRequest(testContext(), req)
+	if err == nil {
+		t.Fatal("expected audience rejection, got nil")
+	}
+	rfc := fosite.ErrorToRFC6749Error(err)
+	if rfc.ErrorField != fosite.ErrInvalidRequest.ErrorField {
+		t.Fatalf("expected invalid_request for bad audience, got %v (%v)", rfc.ErrorField, err)
+	}
+}
+
+func TestROPC_Handle_MissingUsernameRejected(t *testing.T) {
+	store := newTestStore(t, &fakeAuthenticator{}, true)
+	h := newROPCHandler(t, store, newTestConfig())
+
+	req := newROPCRequest(ropcRequestOpts{
+		client: passwordClient([]string{"openid"}, nil),
+		form:   credForm("", "pw", "ropc-client"), // empty username
+	})
+	err := h.HandleTokenEndpointRequest(testContext(), req)
+	rfc := fosite.ErrorToRFC6749Error(err)
+	if rfc.ErrorField != fosite.ErrInvalidRequest.ErrorField {
+		t.Fatalf("expected invalid_request, got %v (%v)", rfc.ErrorField, err)
+	}
+}
+
+func TestROPC_Handle_MissingPasswordRejected(t *testing.T) {
+	store := newTestStore(t, &fakeAuthenticator{}, true)
+	h := newROPCHandler(t, store, newTestConfig())
+
+	req := newROPCRequest(ropcRequestOpts{
+		client: passwordClient([]string{"openid"}, nil),
+		form:   credForm("alice", "", "ropc-client"), // empty password
+	})
+	err := h.HandleTokenEndpointRequest(testContext(), req)
+	rfc := fosite.ErrorToRFC6749Error(err)
+	if rfc.ErrorField != fosite.ErrInvalidRequest.ErrorField {
+		t.Fatalf("expected invalid_request, got %v (%v)", rfc.ErrorField, err)
+	}
+}
+
+func TestROPC_Handle_AuthenticatorErrorBecomesServerError(t *testing.T) {
+	authErr := errors.New("ldap unreachable")
+	store := newTestStore(t, &fakeAuthenticator{
+		authFn: func(context.Context, string, string) (*authenticator.OidcUser, error) {
+			return nil, authErr
+		},
+	}, true)
+	h := newROPCHandler(t, store, newTestConfig())
+
+	req := newROPCRequest(ropcRequestOpts{
+		client: passwordClient([]string{"openid"}, nil),
+		form:   credForm("alice", "pw", "ropc-client"),
+	})
+	err := h.HandleTokenEndpointRequest(testContext(), req)
+	rfc := fosite.ErrorToRFC6749Error(err)
+	if rfc.ErrorField != fosite.ErrServerError.ErrorField {
+		t.Fatalf("expected server_error, got %v (%v)", rfc.ErrorField, err)
+	}
+}
+
+func TestROPC_Handle_NilUserBecomesInvalidGrant(t *testing.T) {
+	// Authenticator returns (nil, nil): bad credentials, no error.
+	store := newTestStore(t, &fakeAuthenticator{
+		authFn: func(context.Context, string, string) (*authenticator.OidcUser, error) {
+			return nil, nil
+		},
+	}, true)
+	h := newROPCHandler(t, store, newTestConfig())
+
+	req := newROPCRequest(ropcRequestOpts{
+		client: passwordClient([]string{"openid"}, nil),
+		form:   credForm("alice", "wrong-pw", "ropc-client"),
+	})
+	err := h.HandleTokenEndpointRequest(testContext(), req)
+	rfc := fosite.ErrorToRFC6749Error(err)
+	if rfc.ErrorField != fosite.ErrInvalidGrant.ErrorField {
+		t.Fatalf("expected invalid_grant, got %v (%v)", rfc.ErrorField, err)
+	}
+}
+
+// --- HandleTokenEndpointRequest: success path ----------------------------
+
+func TestROPC_Handle_SuccessGrantsScopesAndSetsSessionSubject(t *testing.T) {
+	store := newTestStore(t, &fakeAuthenticator{
+		authFn: func(_ context.Context, login, _ string) (*authenticator.OidcUser, error) {
+			return &authenticator.OidcUser{
+				Login:  login,
+				Claims: map[string]interface{}{"email": "alice@example.com"},
+			}, nil
+		},
+	}, true)
+	h := newROPCHandler(t, store, newTestConfig())
+
+	req := newROPCRequest(ropcRequestOpts{
+		client:         passwordClient([]string{"openid", "profile"}, nil),
+		requestedScope: []string{"openid", "profile"},
+		form:           credForm("alice", "pw", "ropc-client"),
+	})
+	if err := h.HandleTokenEndpointRequest(testContext(), req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Scopes granted via HandleScopes.
+	for _, want := range []string{"openid", "profile"} {
+		if !req.GetGrantedScopes().Has(want) {
+			t.Errorf("expected granted scope %q, granted=%v", want, req.GetGrantedScopes())
+		}
+	}
+	// Session must carry the authenticated subject.
+	session, ok := req.GetSession().(*OIDCSession)
+	if !ok {
+		t.Fatalf("session is not *OIDCSession: %T", req.GetSession())
+	}
+	if session.GetSubject() != "alice" {
+		t.Errorf("expected subject alice, got %q", session.GetSubject())
+	}
+	if session.IDTokenClaims_.Extra["email"] != "alice@example.com" {
+		t.Errorf("expected email claim propagated, got %v", session.IDTokenClaims_.Extra)
+	}
+	// azp added because client_id present in form.
+	if session.IDTokenClaims_.Get("azp") != "ropc-client" {
+		t.Errorf("expected azp=ropc-client, got %v", session.IDTokenClaims_.Get("azp"))
+	}
+}
+
+// The password must be scrubbed from the request form after auth so it can
+// never leak into stored sessions / logs.
+func TestROPC_Handle_PasswordDeletedFromForm(t *testing.T) {
+	store := newTestStore(t, &fakeAuthenticator{}, true)
+	h := newROPCHandler(t, store, newTestConfig())
+
+	form := credForm("alice", "super-secret", "ropc-client")
+	req := newROPCRequest(ropcRequestOpts{
+		client: passwordClient([]string{"openid"}, nil),
+		form:   form,
+	})
+	if err := h.HandleTokenEndpointRequest(testContext(), req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := req.GetRequestForm().Get("password"); got != "" {
+		t.Errorf("password must be deleted from form, still present: %q", got)
+	}
+	if got := req.GetRequestForm().Get("username"); got != "alice" {
+		t.Errorf("username should remain, got %q", got)
+	}
+}
+
+func TestROPC_Handle_AccessAndRefreshExpirySet(t *testing.T) {
+	store := newTestStore(t, &fakeAuthenticator{}, true)
+	h := newROPCHandler(t, store, newTestConfig()) // refresh lifespan 24h > -1
+
+	req := newROPCRequest(ropcRequestOpts{
+		client: passwordClient([]string{"openid"}, nil),
+		form:   credForm("alice", "pw", "ropc-client"),
+	})
+	if err := h.HandleTokenEndpointRequest(testContext(), req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if req.GetSession().GetExpiresAt(fosite.AccessToken).IsZero() {
+		t.Error("access-token expiry should be set")
+	}
+	if req.GetSession().GetExpiresAt(fosite.RefreshToken).IsZero() {
+		t.Error("refresh-token expiry should be set for positive refresh lifespan")
+	}
+}
+
+// id-token expiry must only be set when openid scope is granted.
+func TestROPC_Handle_IDTokenExpirySetOnlyWithOpenidScope(t *testing.T) {
+	store := newTestStore(t, &fakeAuthenticator{}, true)
+	h := newROPCHandler(t, store, newTestConfig())
+
+	// With openid.
+	reqWith := newROPCRequest(ropcRequestOpts{
+		client:         passwordClient([]string{"openid", "profile"}, nil),
+		requestedScope: []string{"openid"},
+		form:           credForm("alice", "pw", "ropc-client"),
+	})
+	if err := h.HandleTokenEndpointRequest(testContext(), reqWith); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if reqWith.GetSession().GetExpiresAt(fosite.IDToken).IsZero() {
+		t.Error("id-token expiry should be set when openid is granted")
+	}
+
+	// Without openid.
+	reqWithout := newROPCRequest(ropcRequestOpts{
+		client:         passwordClient([]string{"openid", "profile"}, nil),
+		requestedScope: []string{"profile"},
+		form:           credForm("alice", "pw", "ropc-client"),
+	})
+	if err := h.HandleTokenEndpointRequest(testContext(), reqWithout); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !reqWithout.GetSession().GetExpiresAt(fosite.IDToken).IsZero() {
+		t.Error("id-token expiry must remain unset without openid scope")
+	}
+}
+
+// --- PopulateTokenEndpointResponse: full token issuance ------------------
+
+func TestROPC_Populate_RejectsNonPasswordGrant(t *testing.T) {
+	store := newTestStore(t, &fakeAuthenticator{}, true)
+	h := newROPCHandler(t, store, newTestConfig())
+
+	req := newROPCRequest(ropcRequestOpts{
+		grantType: "authorization_code",
+		client:    passwordClient([]string{"openid"}, nil),
+	})
+	err := h.PopulateTokenEndpointResponse(testContext(), req, fosite.NewAccessResponse())
+	if !errors.Is(err, fosite.ErrUnknownRequest) {
+		t.Fatalf("expected ErrUnknownRequest, got %v", err)
+	}
+}
+
+func TestROPC_Populate_IssuesAccessTokenAndRefreshToken(t *testing.T) {
+	store := newTestStore(t, &fakeAuthenticator{}, true)
+	config := newTestConfig()
+	h := newROPCHandler(t, store, config)
+	ctx := testContext()
+
+	req := newROPCRequest(ropcRequestOpts{
+		client:         passwordClient([]string{"openid"}, nil),
+		requestedScope: []string{"openid"},
+		form:           credForm("alice", "pw", "ropc-client"),
+	})
+	req.SetID("req-1")
+	if err := h.HandleTokenEndpointRequest(ctx, req); err != nil {
+		t.Fatalf("handle failed: %v", err)
+	}
+
+	resp := fosite.NewAccessResponse()
+	if err := h.PopulateTokenEndpointResponse(ctx, req, resp); err != nil {
+		t.Fatalf("populate failed: %v", err)
+	}
+
+	if resp.GetAccessToken() == "" {
+		t.Error("access token should be populated")
+	}
+	if resp.GetTokenType() != "bearer" {
+		t.Errorf("expected bearer token type, got %q", resp.GetTokenType())
+	}
+	// refresh_token granted because client did not request offline scopes
+	// AND RefreshTokenScopes is non-empty (HasOneOf is false -> issue? see
+	// logic). The handler issues a refresh token when granted scopes include
+	// one of the refresh scopes OR refresh scopes config is empty. With
+	// neither, no refresh token is issued.
+	if resp.GetExtra("refresh_token") != nil {
+		t.Errorf("no refresh token expected without offline scope, got %v", resp.GetExtra("refresh_token"))
+	}
+	// id_token must be present because openid was granted.
+	if resp.GetExtra("id_token") == nil {
+		t.Error("id_token should be present when openid granted")
+	}
+	// Access token must have been persisted in storage.
+	if len(store.AccessTokens) == 0 {
+		t.Error("access token session should be stored")
+	}
+}
+
+func TestROPC_Populate_RefreshTokenIssuedWithOfflineScope(t *testing.T) {
+	store := newTestStore(t, &fakeAuthenticator{}, true)
+	config := newTestConfig()
+	h := newROPCHandler(t, store, config)
+	ctx := testContext()
+
+	req := newROPCRequest(ropcRequestOpts{
+		client:         passwordClient([]string{"openid", "offline"}, nil),
+		requestedScope: []string{"openid", "offline"},
+		form:           credForm("alice", "pw", "ropc-client"),
+	})
+	req.SetID("req-2")
+	if err := h.HandleTokenEndpointRequest(ctx, req); err != nil {
+		t.Fatalf("handle failed: %v", err)
+	}
+	resp := fosite.NewAccessResponse()
+	if err := h.PopulateTokenEndpointResponse(ctx, req, resp); err != nil {
+		t.Fatalf("populate failed: %v", err)
+	}
+	if resp.GetExtra("refresh_token") == nil {
+		t.Error("refresh token expected when offline scope granted")
+	}
+	if len(store.RefreshTokens) == 0 {
+		t.Error("refresh token session should be stored")
+	}
+}
+
+// id_token must be omitted when openid was not granted.
+func TestROPC_Populate_NoIDTokenWithoutOpenid(t *testing.T) {
+	store := newTestStore(t, &fakeAuthenticator{}, true)
+	h := newROPCHandler(t, store, newTestConfig())
+	ctx := testContext()
+
+	req := newROPCRequest(ropcRequestOpts{
+		client:         passwordClient([]string{"openid", "profile"}, nil),
+		requestedScope: []string{"profile"},
+		form:           credForm("alice", "pw", "ropc-client"),
+	})
+	req.SetID("req-3")
+	if err := h.HandleTokenEndpointRequest(ctx, req); err != nil {
+		t.Fatalf("handle failed: %v", err)
+	}
+	resp := fosite.NewAccessResponse()
+	if err := h.PopulateTokenEndpointResponse(ctx, req, resp); err != nil {
+		t.Fatalf("populate failed: %v", err)
+	}
+	if resp.GetExtra("id_token") != nil {
+		t.Errorf("id_token must be absent without openid, got %v", resp.GetExtra("id_token"))
+	}
+}

--- a/cmd/oidc/fositepatch/helpers_test.go
+++ b/cmd/oidc/fositepatch/helpers_test.go
@@ -1,0 +1,141 @@
+/*
+Copyright (c) 2025 Kubotal.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package fositepatch
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"kubauth/cmd/oidc/authenticator"
+	"kubauth/cmd/oidc/oidcstorage"
+	"kubauth/internal/proto"
+
+	"github.com/go-logr/logr"
+	"github.com/ory/hydra/v2/fosite"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"kubauth/api/kubauth/v1alpha1"
+)
+
+// discardLogger returns a slog.Logger that throws output away so the
+// handlers under test can log freely without polluting test output.
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// testContext returns a context carrying a (discard) slog logger, exactly
+// as the production entrypoint does via logr.NewContextWithSlogLogger.
+// The ROPC handler calls logr.FromContextAsSlogLogger(ctx) and then logs
+// without a nil check, so callers must inject a logger or the handler
+// panics on the error/success paths.
+func testContext() context.Context {
+	return logr.NewContextWithSlogLogger(context.Background(), discardLogger())
+}
+
+// boolPtr is a tiny helper for the *bool spec fields.
+func boolPtr(b bool) *bool { return &b }
+
+// testClientOpts configures the OidcClient backing a test KubauthClient.
+type testClientOpts struct {
+	clientID         string
+	scopes           []string
+	audiences        []string
+	grantTypes       []string
+	forceOpenIDScope *bool
+}
+
+// newTestClient builds a real oidcstorage.KubauthClient from an OidcClient
+// CR. Using the production client type (rather than a hand-rolled fake)
+// means the scope/audience handlers exercise the same GetAudience /
+// IsForceOpenIdScope logic that runs in production.
+func newTestClient(o testClientOpts) oidcstorage.KubauthClient {
+	if o.clientID == "" {
+		o.clientID = "test-client"
+	}
+	cli := &v1alpha1.OidcClient{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "kubauth-system",
+			Name:      o.clientID,
+		},
+		Spec: v1alpha1.OidcClientSpec{
+			RedirectURIs:     []string{"https://app/callback"},
+			GrantTypes:       o.grantTypes,
+			ResponseTypes:    []string{"code"},
+			Scopes:           o.scopes,
+			Audiences:        o.audiences,
+			ForceOpenIdScope: o.forceOpenIDScope,
+		},
+	}
+	return oidcstorage.NewKubauthClient(cli, o.clientID, nil)
+}
+
+// fakeAuthenticator is a configurable authenticator.OidcAuthenticator used
+// to drive the ROPC flow down its success / failure / nil-user branches
+// without any real LDAP or HTTP backend.
+type fakeAuthenticator struct {
+	// authFn backs Authenticate (and, through MemoryStore, AuthenticateUserWithClaims).
+	authFn func(ctx context.Context, login, password string) (*authenticator.OidcUser, error)
+}
+
+func (f *fakeAuthenticator) Identify(_ context.Context, login, _ string) (*authenticator.OidcUser, proto.Status, error) {
+	return &authenticator.OidcUser{Login: login}, proto.Status("ok"), nil
+}
+
+func (f *fakeAuthenticator) Authenticate(ctx context.Context, login, password string) (*authenticator.OidcUser, error) {
+	if f.authFn == nil {
+		return &authenticator.OidcUser{Login: login}, nil
+	}
+	return f.authFn(ctx, login, password)
+}
+
+var _ authenticator.OidcAuthenticator = (*fakeAuthenticator)(nil)
+
+// newTestStore builds a MemoryStore wired to the given authenticator with
+// the password grant flag configured. issuer/keyID mirror what the real
+// server sets so id-token claims look realistic.
+func newTestStore(t *testing.T, auth authenticator.OidcAuthenticator, allowPasswordGrant bool) *oidcstorage.MemoryStore {
+	t.Helper()
+	store := oidcstorage.NewMemoryStore(auth)
+	store.Issuer = "https://issuer.example.com"
+	store.KeyID = "test-kid"
+	store.AllowPasswordGrant = allowPasswordGrant
+	return store
+}
+
+// newTestConfig builds a fosite.Config mirroring the production wiring in
+// oidcserver.go (32-byte global secret, exact lifespans, offline refresh
+// scopes). The ExactScopeStrategy is set explicitly so scope filtering in
+// the ROPC handler is deterministic.
+func newTestConfig() *fosite.Config {
+	return &fosite.Config{
+		AccessTokenLifespan:  time.Hour,
+		RefreshTokenLifespan: 24 * time.Hour,
+		IDTokenLifespan:      time.Hour,
+		TokenEntropy:         32,
+		GlobalSecret:         []byte("some-secret-that-is-32-bytes-long"),
+		RefreshTokenScopes:   []string{"offline", "offline_access"},
+		AccessTokenIssuer:    "https://issuer.example.com",
+		IDTokenIssuer:        "https://issuer.example.com",
+		ScopeStrategy:        fosite.ExactScopeStrategy,
+	}
+}
+
+// newTestKey generates an RSA key for signing, matching oidcserver.go.
+func newTestKey(t *testing.T) *rsa.PrivateKey {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate RSA key: %v", err)
+	}
+	return key
+}

--- a/cmd/oidc/fositepatch/helpers_test.go
+++ b/cmd/oidc/fositepatch/helpers_test.go
@@ -113,7 +113,7 @@ func newTestStore(t *testing.T, auth authenticator.OidcAuthenticator, allowPassw
 }
 
 // newTestConfig builds a fosite.Config mirroring the production wiring in
-// oidcserver.go (32-byte global secret, exact lifespans, offline refresh
+// oidcserver.go (same global secret, exact lifespans, offline refresh
 // scopes). The ExactScopeStrategy is set explicitly so scope filtering in
 // the ROPC handler is deterministic.
 func newTestConfig() *fosite.Config {

--- a/cmd/oidc/fositepatch/scopehandler_test.go
+++ b/cmd/oidc/fositepatch/scopehandler_test.go
@@ -1,0 +1,195 @@
+/*
+Copyright (c) 2025 Kubotal.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package fositepatch
+
+import (
+	"testing"
+
+	"github.com/ory/hydra/v2/fosite"
+)
+
+// scopeReqWith builds a real *fosite.AccessRequest carrying the given
+// requested scopes and client. HandleScopes only depends on the
+// ScopeRequester surface, which *fosite.AccessRequest satisfies.
+func scopeReqWith(client fosite.Client, requested ...string) *fosite.AccessRequest {
+	ar := fosite.NewAccessRequest(&OIDCSession{})
+	ar.Client = client
+	ar.RequestedScope = fosite.Arguments(requested)
+	return ar
+}
+
+func contains(args fosite.Arguments, s string) bool {
+	for _, a := range args {
+		if a == s {
+			return true
+		}
+	}
+	return false
+}
+
+func count(args fosite.Arguments, s string) int {
+	n := 0
+	for _, a := range args {
+		if a == s {
+			n++
+		}
+	}
+	return n
+}
+
+// --- HandleScopes --------------------------------------------------------
+
+func TestHandleScopes_GrantsAllRequestedScopes(t *testing.T) {
+	client := newTestClient(testClientOpts{scopes: []string{"openid", "profile", "email"}})
+	ar := scopeReqWith(client, "openid", "profile", "email")
+
+	HandleScopes(ar, discardLogger())
+
+	granted := ar.GetGrantedScopes()
+	for _, want := range []string{"openid", "profile", "email"} {
+		if !contains(granted, want) {
+			t.Errorf("expected scope %q to be granted, granted=%v", want, granted)
+		}
+	}
+}
+
+func TestHandleScopes_GrantsNothingWhenNoneRequested(t *testing.T) {
+	client := newTestClient(testClientOpts{scopes: []string{"openid"}})
+	ar := scopeReqWith(client) // no requested scopes
+
+	HandleScopes(ar, discardLogger())
+
+	if got := len(ar.GetGrantedScopes()); got != 0 {
+		t.Errorf("expected no granted scopes, got %v", ar.GetGrantedScopes())
+	}
+}
+
+// HandleScopes grants exactly what was requested. It deliberately does NOT
+// re-filter against the client scope list (the comment in scopehandler.go
+// notes that out-of-list scopes are rejected upstream). This test pins that
+// contract so a future "defensive filter" change is a conscious decision.
+func TestHandleScopes_DoesNotFilterAgainstClientScopeList(t *testing.T) {
+	client := newTestClient(testClientOpts{scopes: []string{"openid"}})
+	ar := scopeReqWith(client, "openid", "not-in-client-list")
+
+	HandleScopes(ar, discardLogger())
+
+	if !contains(ar.GetGrantedScopes(), "not-in-client-list") {
+		t.Errorf("HandleScopes should grant requested scopes verbatim, granted=%v", ar.GetGrantedScopes())
+	}
+}
+
+func TestHandleScopes_ForceOpenIdAddsOpenidWhenNotRequested(t *testing.T) {
+	client := newTestClient(testClientOpts{
+		scopes:           []string{"openid", "profile"},
+		forceOpenIDScope: boolPtr(true),
+	})
+	ar := scopeReqWith(client, "profile") // openid NOT requested
+
+	HandleScopes(ar, discardLogger())
+
+	if !contains(ar.GetGrantedScopes(), "openid") {
+		t.Errorf("force-openid client should have openid granted, granted=%v", ar.GetGrantedScopes())
+	}
+}
+
+func TestHandleScopes_ForceOpenIdDoesNotDuplicateOpenid(t *testing.T) {
+	client := newTestClient(testClientOpts{
+		scopes:           []string{"openid"},
+		forceOpenIDScope: boolPtr(true),
+	})
+	ar := scopeReqWith(client, "openid") // already requested
+
+	HandleScopes(ar, discardLogger())
+
+	// fosite.GrantScope dedupes, so openid must appear exactly once.
+	if c := count(ar.GetGrantedScopes(), "openid"); c != 1 {
+		t.Errorf("openid should be granted exactly once, got %d (granted=%v)", c, ar.GetGrantedScopes())
+	}
+}
+
+func TestHandleScopes_ForceOpenIdFalseDoesNotAddOpenid(t *testing.T) {
+	client := newTestClient(testClientOpts{
+		scopes:           []string{"openid", "profile"},
+		forceOpenIDScope: boolPtr(false),
+	})
+	ar := scopeReqWith(client, "profile")
+
+	HandleScopes(ar, discardLogger())
+
+	if contains(ar.GetGrantedScopes(), "openid") {
+		t.Errorf("force-openid=false must not inject openid, granted=%v", ar.GetGrantedScopes())
+	}
+}
+
+// A non-KubauthClient (plain fosite client) must not trip the force-openid
+// type assertion. This guards the `if client2, ok := ...` branch.
+func TestHandleScopes_NonKubauthClientSkipsForceOpenid(t *testing.T) {
+	plain := &fosite.DefaultClient{ID: "plain", Scopes: []string{"profile"}}
+	ar := scopeReqWith(plain, "profile")
+
+	HandleScopes(ar, discardLogger())
+
+	if !contains(ar.GetGrantedScopes(), "profile") {
+		t.Errorf("requested scope should still be granted for plain client, granted=%v", ar.GetGrantedScopes())
+	}
+	if contains(ar.GetGrantedScopes(), "openid") {
+		t.Errorf("plain client must not get force-openid injection, granted=%v", ar.GetGrantedScopes())
+	}
+}
+
+// --- HandleAudience ------------------------------------------------------
+
+func audienceReqWith(client fosite.Client, requested ...string) *fosite.AccessRequest {
+	ar := fosite.NewAccessRequest(&OIDCSession{})
+	ar.Client = client
+	ar.RequestedAudience = fosite.Arguments(requested)
+	return ar
+}
+
+func TestHandleAudience_GrantsRequestedAudience(t *testing.T) {
+	client := newTestClient(testClientOpts{clientID: "cid", audiences: []string{"api-a", "api-b"}})
+	ar := audienceReqWith(client, "api-a", "api-b")
+
+	HandleAudience(ar, discardLogger())
+
+	granted := ar.GetGrantedAudience()
+	for _, want := range []string{"api-a", "api-b"} {
+		if !contains(granted, want) {
+			t.Errorf("expected audience %q granted, granted=%v", want, granted)
+		}
+	}
+	// client_id must NOT be force-added when explicit audiences are present.
+	if contains(granted, "cid") {
+		t.Errorf("client_id should not be granted when audience explicitly requested, granted=%v", granted)
+	}
+}
+
+func TestHandleAudience_DefaultsToClientIdWhenNoneRequested(t *testing.T) {
+	client := newTestClient(testClientOpts{clientID: "my-client-id"})
+	ar := audienceReqWith(client) // no requested audience
+
+	HandleAudience(ar, discardLogger())
+
+	granted := ar.GetGrantedAudience()
+	if len(granted) != 1 || granted[0] != "my-client-id" {
+		t.Errorf("expected client_id as sole default audience, got %v", granted)
+	}
+}
+
+func TestHandleAudience_SingleRequestedAudience(t *testing.T) {
+	client := newTestClient(testClientOpts{clientID: "cid", audiences: []string{"only-api"}})
+	ar := audienceReqWith(client, "only-api")
+
+	HandleAudience(ar, discardLogger())
+
+	granted := ar.GetGrantedAudience()
+	if len(granted) != 1 || granted[0] != "only-api" {
+		t.Errorf("expected only-api as sole granted audience, got %v", granted)
+	}
+}

--- a/cmd/oidc/fositepatch/session_test.go
+++ b/cmd/oidc/fositepatch/session_test.go
@@ -1,0 +1,228 @@
+/*
+Copyright (c) 2025 Kubotal.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package fositepatch
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ory/hydra/v2/fosite"
+	"github.com/ory/hydra/v2/fosite/token/jwt"
+)
+
+// Constructor / clone -----------------------------------------------------
+
+func TestOIDCSession_Clone_NilReturnsNil(t *testing.T) {
+	var s *OIDCSession
+	if got := s.Clone(); got != nil {
+		t.Errorf("nil receiver Clone() should be nil, got %v", got)
+	}
+}
+
+func TestOIDCSession_Clone_DeepCopiesIndependentSession(t *testing.T) {
+	s := &OIDCSession{
+		Username: "alice",
+		Subject:  "user-123",
+		IDTokenClaims_: &jwt.IDTokenClaims{
+			Subject: "user-123",
+			Extra:   map[string]interface{}{"k": "v"},
+		},
+	}
+	cloned := s.Clone().(*OIDCSession)
+	// Mutate the clone — original should be untouched.
+	cloned.Username = "bob"
+	cloned.IDTokenClaims_.Extra["k"] = "mutated"
+	if s.Username != "alice" {
+		t.Errorf("clone mutation leaked into original Username: %q", s.Username)
+	}
+	if s.IDTokenClaims_.Extra["k"] != "v" {
+		t.Errorf("clone mutation leaked into original IDTokenClaims_.Extra: %v", s.IDTokenClaims_.Extra)
+	}
+}
+
+// SetAudience -------------------------------------------------------------
+
+func TestOIDCSession_SetAudience_UpdatesBothClaimsContainers(t *testing.T) {
+	s := &OIDCSession{
+		IDTokenClaims_: &jwt.IDTokenClaims{},
+		JWTClaims_:     &jwt.JWTClaims{},
+	}
+	aud := []string{"client-a", "client-b"}
+	s.SetAudience(aud)
+	if got := s.IDTokenClaims_.Audience; len(got) != 2 || got[0] != "client-a" || got[1] != "client-b" {
+		t.Errorf("ID token audience not set correctly: %v", got)
+	}
+	if got := s.JWTClaims_.Audience; len(got) != 2 || got[0] != "client-a" || got[1] != "client-b" {
+		t.Errorf("JWT audience not set correctly: %v", got)
+	}
+}
+
+// ExpiresAt round-trip ----------------------------------------------------
+
+func TestOIDCSession_GetExpiresAt_UnsetReturnsZeroTime(t *testing.T) {
+	s := &OIDCSession{}
+	if got := s.GetExpiresAt(fosite.AccessToken); !got.IsZero() {
+		t.Errorf("unset expiry should return zero Time, got %v", got)
+	}
+}
+
+func TestOIDCSession_GetExpiresAt_NilMapDoesNotPanic(t *testing.T) {
+	// Documented behaviour: GetExpiresAt initialises ExpiresAt map on
+	// the fly if nil. A nil-map panic here would crash any caller
+	// inspecting expiries on a freshly-deserialised session.
+	s := &OIDCSession{ExpiresAt: nil}
+	if got := s.GetExpiresAt(fosite.RefreshToken); !got.IsZero() {
+		t.Errorf("nil-map fallback should return zero Time, got %v", got)
+	}
+	if s.ExpiresAt == nil {
+		t.Error("GetExpiresAt should have initialised the map")
+	}
+}
+
+func TestOIDCSession_SetExpiresAt_RoundTrips(t *testing.T) {
+	s := &OIDCSession{}
+	t0 := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	s.SetExpiresAt(fosite.AccessToken, t0)
+	if got := s.GetExpiresAt(fosite.AccessToken); !got.Equal(t0) {
+		t.Errorf("expected %v, got %v", t0, got)
+	}
+}
+
+func TestOIDCSession_SetExpiresAt_NilMapInitialised(t *testing.T) {
+	s := &OIDCSession{ExpiresAt: nil}
+	t0 := time.Now().UTC()
+	s.SetExpiresAt(fosite.AccessToken, t0)
+	if s.ExpiresAt == nil {
+		t.Error("SetExpiresAt should have initialised the map")
+	}
+	if got := s.ExpiresAt[fosite.AccessToken]; !got.Equal(t0) {
+		t.Errorf("expected %v, got %v", t0, got)
+	}
+}
+
+func TestOIDCSession_SetExpiresAt_PerTokenTypeIndependence(t *testing.T) {
+	s := &OIDCSession{}
+	tA := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	tR := time.Date(2027, 6, 1, 0, 0, 0, 0, time.UTC)
+	s.SetExpiresAt(fosite.AccessToken, tA)
+	s.SetExpiresAt(fosite.RefreshToken, tR)
+	if !s.GetExpiresAt(fosite.AccessToken).Equal(tA) {
+		t.Error("access-token expiry overwritten")
+	}
+	if !s.GetExpiresAt(fosite.RefreshToken).Equal(tR) {
+		t.Error("refresh-token expiry overwritten")
+	}
+}
+
+// Username / Subject ------------------------------------------------------
+
+func TestOIDCSession_GetUsername_NilReceiverReturnsEmpty(t *testing.T) {
+	var s *OIDCSession
+	if got := s.GetUsername(); got != "" {
+		t.Errorf("nil receiver should return empty username, got %q", got)
+	}
+}
+
+func TestOIDCSession_GetUsername_ReturnsField(t *testing.T) {
+	s := &OIDCSession{Username: "alice"}
+	if got := s.GetUsername(); got != "alice" {
+		t.Errorf("expected alice, got %q", got)
+	}
+}
+
+func TestOIDCSession_SetGetSubject(t *testing.T) {
+	s := &OIDCSession{}
+	s.SetSubject("user-1")
+	if got := s.GetSubject(); got != "user-1" {
+		t.Errorf("expected user-1, got %q", got)
+	}
+}
+
+func TestOIDCSession_GetSubject_NilReceiverReturnsEmpty(t *testing.T) {
+	var s *OIDCSession
+	if got := s.GetSubject(); got != "" {
+		t.Errorf("nil receiver should return empty subject, got %q", got)
+	}
+}
+
+// IDTokenHeaders / IDTokenClaims (lazy init) ------------------------------
+
+func TestOIDCSession_IDTokenHeaders_LazyInit(t *testing.T) {
+	s := &OIDCSession{Headers: nil}
+	h := s.IDTokenHeaders()
+	if h == nil {
+		t.Fatal("IDTokenHeaders should never return nil")
+	}
+	if s.Headers == nil {
+		t.Error("IDTokenHeaders should have initialised s.Headers")
+	}
+}
+
+func TestOIDCSession_IDTokenClaims_LazyInit(t *testing.T) {
+	s := &OIDCSession{IDTokenClaims_: nil}
+	c := s.IDTokenClaims()
+	if c == nil {
+		t.Fatal("IDTokenClaims should never return nil")
+	}
+	if s.IDTokenClaims_ == nil {
+		t.Error("IDTokenClaims should have initialised s.IDTokenClaims_")
+	}
+}
+
+func TestOIDCSession_IDTokenHeaders_ReturnsExisting(t *testing.T) {
+	existing := &jwt.Headers{Extra: map[string]interface{}{"kid": "key-1"}}
+	s := &OIDCSession{Headers: existing}
+	if got := s.IDTokenHeaders(); got != existing {
+		t.Error("IDTokenHeaders should return the existing instance, not a fresh one")
+	}
+}
+
+// JWTSessionContainer -----------------------------------------------------
+
+func TestOIDCSession_GetJWTClaims_LazyInit(t *testing.T) {
+	s := &OIDCSession{JWTClaims_: nil}
+	c := s.GetJWTClaims()
+	if c == nil {
+		t.Fatal("GetJWTClaims should never return nil")
+	}
+	if s.JWTClaims_ == nil {
+		t.Error("GetJWTClaims should have initialised s.JWTClaims_")
+	}
+}
+
+func TestOIDCSession_GetJWTHeader_LazyInit(t *testing.T) {
+	s := &OIDCSession{Headers: nil}
+	h := s.GetJWTHeader()
+	if h == nil {
+		t.Fatal("GetJWTHeader should never return nil")
+	}
+	if s.Headers == nil {
+		t.Error("GetJWTHeader should have initialised s.Headers")
+	}
+}
+
+func TestOIDCSession_HeadersSharedBetweenIDAndJWT(t *testing.T) {
+	// Both IDTokenHeaders and GetJWTHeader return s.Headers — same
+	// instance. A change visible via one path must be visible via the
+	// other.
+	s := &OIDCSession{}
+	idH := s.IDTokenHeaders()
+	jwtH := s.GetJWTHeader()
+	if idH != jwtH {
+		t.Error("ID-token headers and JWT headers must be the same Headers instance")
+	}
+}
+
+// Interface compliance is enforced by the var _ assertions in session.go
+// — adding a runtime check here too so anyone breaking the contract via
+// a method-signature change gets a test failure, not just a build error
+// at use-site.
+func TestOIDCSession_ImplementsExpectedInterfaces(t *testing.T) {
+	s := &OIDCSession{}
+	var _ fosite.Session = s
+}

--- a/cmd/oidc/oidcserver/fixture_test.go
+++ b/cmd/oidc/oidcserver/fixture_test.go
@@ -1,0 +1,482 @@
+/*
+Copyright (c) 2025 Kubotal.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+// Shared test fixture for the OIDC HTTP handlers.
+//
+// buildServer wires a real fosite provider (via fositepatch.ComposeAllEnabled),
+// the real in-memory storage (oidcstorage.MemoryStore), real scs session
+// managers (in-memory store) and a fake controller-runtime k8s client. The
+// returned *http.ServeMux is what Setup() registers, so handlers are exercised
+// through the exact same routing/middleware stack as production.
+//
+// The fake authenticator lets a test decide what user (and claims) a
+// login/password produces, which is the seam used to mint real authorization
+// codes and then exchange them for tokens.
+package oidcserver
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"html/template"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"kubauth/api/kubauth/v1alpha1"
+	"kubauth/cmd/oidc/authenticator"
+	"kubauth/cmd/oidc/oidcstorage"
+	"kubauth/cmd/oidc/sessioncodec"
+	"kubauth/internal/proto"
+
+	scsV2 "github.com/alexedwards/scs/v2"
+	scsmem "github.com/alexedwards/scs/v2/memstore"
+	"github.com/go-logr/logr"
+	"golang.org/x/crypto/bcrypt"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// ----------------------------------------------------------------- constants
+
+const (
+	testIssuer       = "https://idp.test"
+	testClientID     = "web-app"
+	testClientSecret = "s3cr3t-value"
+	testPublicClient = "spa-app"
+	testRedirectURI  = "https://app.test/callback"
+	testUserLogin    = "alice"
+	testUserPassword = "correct-horse"
+)
+
+// ----------------------------------------------------------------- logger ctx
+
+// testCtx returns a context carrying a discard slog logger. Many handlers and
+// storage methods call logr.FromContextAsSlogLogger(ctx) and would panic on a
+// bare context.Background().
+func testCtx() context.Context {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	return logr.NewContextWithSlogLogger(context.Background(), logger)
+}
+
+// ----------------------------------------------------------- fake authenticator
+
+// fakeAuthenticator is a controllable OidcAuthenticator. authFunc backs
+// Authenticate (password-checked login), identFunc backs Identify.
+type fakeAuthenticator struct {
+	authFunc  func(ctx context.Context, login, password string) (*authenticator.OidcUser, error)
+	identFunc func(ctx context.Context, login, password string) (*authenticator.OidcUser, proto.Status, error)
+}
+
+func (f *fakeAuthenticator) Authenticate(ctx context.Context, login, password string) (*authenticator.OidcUser, error) {
+	if f.authFunc != nil {
+		return f.authFunc(ctx, login, password)
+	}
+	return nil, nil
+}
+
+func (f *fakeAuthenticator) Identify(ctx context.Context, login, password string) (*authenticator.OidcUser, proto.Status, error) {
+	if f.identFunc != nil {
+		return f.identFunc(ctx, login, password)
+	}
+	return nil, proto.UserNotFound, nil
+}
+
+var _ authenticator.OidcAuthenticator = (*fakeAuthenticator)(nil)
+
+// defaultAuth returns an authenticator that accepts exactly testUserLogin /
+// testUserPassword and returns a user carrying a representative claim set.
+func defaultAuth() *fakeAuthenticator {
+	return &fakeAuthenticator{
+		authFunc: func(_ context.Context, login, password string) (*authenticator.OidcUser, error) {
+			if login == testUserLogin && password == testUserPassword {
+				return &authenticator.OidcUser{
+					Login:    testUserLogin,
+					FullName: "Alice Example",
+					Claims: map[string]interface{}{
+						"sub":            testUserLogin,
+						"name":           "Alice Example",
+						"email":          "alice@test",
+						"email_verified": true,
+						"groups":         []string{"dev", "admin"},
+					},
+				}, nil
+			}
+			// nil user => invalid credentials (not an error)
+			return nil, nil
+		},
+	}
+}
+
+// ----------------------------------------------------------------- templates
+
+// Minimal templates so login/index/welcome handlers can render without the
+// real resource files. Field names match the model structs.
+func testTemplates() (login, index, welcome *template.Template) {
+	login = template.Must(template.New("login").Parse(
+		`<html><body>LOGIN invalid={{.InvalidLogin}} form={{.ShowLoginForm}} noprov={{.ShowNoProviderMessage}}{{range .UpstreamButtons}} btn:{{.Name}}{{end}}</body></html>`))
+	index = template.Must(template.New("index").Parse(
+		`<html><body>INDEX{{range .Entries}} app:{{.DisplayName}}|{{.EntryURL}}{{end}}</body></html>`))
+	welcome = template.Must(template.New("welcome").Parse(
+		`<html><body>WELCOME {{.UserName}}</body></html>`))
+	return
+}
+
+// ----------------------------------------------------------------- k8s client
+
+func newScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := scheme.AddToScheme(s); err != nil { // core/v1 (Secret)
+		t.Fatalf("clientgo AddToScheme: %v", err)
+	}
+	if err := v1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("v1alpha1 AddToScheme: %v", err)
+	}
+	return s
+}
+
+// preGeneratedKeySecret returns a Secret already holding an RSA key + kid, so
+// ensureJwtSigningKey takes the "load existing" branch deterministically.
+func preGeneratedKeySecret(t *testing.T, name, ns string) (*corev1.Secret, *rsa.PrivateKey, string) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa keygen: %v", err)
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+	const kid = "test-kid-1"
+	sec := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Type:       corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			"key.pem": pemBytes,
+			"kid":     []byte(kid),
+		},
+	}
+	return sec, key, kid
+}
+
+// ----------------------------------------------------------------- clients
+
+// confidentialClient builds a registered confidential client supporting the
+// authorization-code + refresh-token + client-credentials grants.
+func confidentialClient(t *testing.T) oidcstorage.KubauthClient {
+	t.Helper()
+	h, err := bcrypt.GenerateFromPassword([]byte(testClientSecret), bcrypt.MinCost)
+	if err != nil {
+		t.Fatalf("bcrypt: %v", err)
+	}
+	cli := &v1alpha1.OidcClient{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "kubauth-system", Name: testClientID},
+		Spec: v1alpha1.OidcClientSpec{
+			RedirectURIs:  []string{testRedirectURI},
+			GrantTypes:    []string{"authorization_code", "refresh_token", "client_credentials"},
+			ResponseTypes: []string{"code"},
+			Scopes:        []string{"openid", "profile", "email", "groups", "offline"},
+			Audiences:     []string{testClientID},
+			Public:        false,
+			DisplayName:   "Web App",
+			EntryURL:      "https://app.test/",
+			Description:   "the web app",
+		},
+	}
+	return oidcstorage.NewKubauthClient(cli, testClientID, [][]byte{h})
+}
+
+// publicClient builds a registered public client (no secret) using PKCE.
+func publicClient(t *testing.T) oidcstorage.KubauthClient {
+	t.Helper()
+	cli := &v1alpha1.OidcClient{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "kubauth-system", Name: testPublicClient},
+		Spec: v1alpha1.OidcClientSpec{
+			RedirectURIs:  []string{testRedirectURI},
+			GrantTypes:    []string{"authorization_code", "refresh_token"},
+			ResponseTypes: []string{"code"},
+			Scopes:        []string{"openid", "profile", "email", "offline"},
+			Public:        true,
+			DisplayName:   "SPA App",
+			EntryURL:      "https://spa.test/",
+		},
+	}
+	return oidcstorage.NewKubauthClient(cli, testPublicClient, nil)
+}
+
+// ----------------------------------------------------------------- fixture
+
+// testServer bundles the wired server, its mux and the knobs a test may swap.
+type testServer struct {
+	srv    *OIDCServer
+	mux    *http.ServeMux
+	auth   *fakeAuthenticator
+	store  *oidcstorage.MemoryStore
+	kube   client.Client
+	key    *rsa.PrivateKey
+	kid    string
+	issuer string
+}
+
+type buildOpts struct {
+	auth               *fakeAuthenticator
+	clients            []oidcstorage.KubauthClient
+	ssoMode            SsoMode
+	allowPasswordGrant bool
+	enforcePKCE        bool
+	jwtAccessToken     bool
+	kubeObjects        []client.Object
+}
+
+// buildServer wires a ready-to-serve OIDCServer with sane defaults. Tests pass
+// option mutators to customise. It calls the real Setup(), so JWKS/issuer/keyID
+// are all derived exactly as in production.
+func buildServer(t *testing.T, mutators ...func(*buildOpts)) *testServer {
+	t.Helper()
+	opts := &buildOpts{
+		auth:    defaultAuth(),
+		clients: []oidcstorage.KubauthClient{confidentialClient(t)},
+		ssoMode: SsoNever,
+	}
+	for _, m := range mutators {
+		m(opts)
+	}
+
+	const secretName, secretNS = "kubauth-jwt-key", "kubauth-system"
+	sec, key, kid := preGeneratedKeySecret(t, secretName, secretNS)
+
+	objs := append([]client.Object{sec}, opts.kubeObjects...)
+	kube := fake.NewClientBuilder().WithScheme(newScheme(t)).WithObjects(objs...).Build()
+
+	return buildServerWithClient(t, opts, kube, key, kid, secretName, secretNS)
+}
+
+// buildServerWithClient is the shared tail used by buildServer and by tests
+// that need to inject a fake client with interceptors.
+func buildServerWithClient(t *testing.T, opts *buildOpts, kube client.Client, key *rsa.PrivateKey, kid, secretName, secretNS string) *testServer {
+	t.Helper()
+
+	store := oidcstorage.NewMemoryStore(opts.auth)
+	for _, c := range opts.clients {
+		if err := store.SetClient(testCtx(), c); err != nil {
+			t.Fatalf("SetClient: %v", err)
+		}
+	}
+
+	loginTmpl, indexTmpl, welcomeTmpl := testTemplates()
+
+	sso := scsV2.New()
+	sso.Store = scsmem.New()
+	// Match production: the SSO session is serialised with the JSON codec, so a
+	// stored *OidcUser round-trips back as map[string]interface{} — which is
+	// exactly what handleLogin's SSO-reuse path type-asserts.
+	sso.Codec = sessioncodec.JSONCodec{}
+	login := scsV2.New()
+	login.Store = scsmem.New()
+
+	srv := &OIDCServer{
+		Issuer:                  testIssuer,
+		Storage:                 store,
+		Authenticator:           opts.auth,
+		Resources:               t.TempDir(),
+		LoginTemplate:           loginTmpl,
+		IndexTemplate:           indexTmpl,
+		UpstreamWelcomeTemplate: welcomeTmpl,
+		SsoSessionManager:       sso,
+		LoginSessionManager:     login,
+		PostLogoutURL:           "https://idp.test/loggedout",
+		KubeClient:              kube,
+		EventRecorder:           record.NewFakeRecorder(64),
+		JWTSigningKeySecretName: secretName,
+		JWTSigningKeySecretNS:   secretNS,
+		AccessTokenLifespan:     time.Hour,
+		RefreshTokenLifespan:    time.Hour,
+		AllowPasswordGrant:      opts.allowPasswordGrant,
+		EnforcePKCE:             opts.enforcePKCE,
+		JwtAccessToken:          opts.jwtAccessToken,
+		DefaultStyle:            "default",
+		SsoMode:                 opts.ssoMode,
+		DefaultLoginLabel:       "Sign in",
+	}
+
+	mux := http.NewServeMux()
+	if err := srv.Setup(testCtx(), mux); err != nil {
+		t.Fatalf("Setup: %v", err)
+	}
+
+	return &testServer{
+		srv:    srv,
+		mux:    mux,
+		auth:   opts.auth,
+		store:  store,
+		kube:   kube,
+		key:    key,
+		kid:    kid,
+		issuer: testIssuer,
+	}
+}
+
+// ----------------------------------------------------------------- request helpers
+
+// do sends a request through the mux and returns the recorder. The request
+// already carries the discard-logger context.
+func (ts *testServer) do(req *http.Request) *httptest.ResponseRecorder {
+	rr := httptest.NewRecorder()
+	ts.mux.ServeHTTP(rr, req.WithContext(testCtx()))
+	return rr
+}
+
+func newGet(t *testing.T, path string) *http.Request {
+	t.Helper()
+	return httptest.NewRequest(http.MethodGet, path, nil)
+}
+
+func newPostForm(t *testing.T, path string, form url.Values) *http.Request {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	return req
+}
+
+// ----------------------------------------------------------------- flow helper
+
+// authzQuery builds the query string for an authorization-code request.
+func authzQuery(clientID, scope string, extra url.Values) url.Values {
+	q := url.Values{}
+	q.Set("response_type", "code")
+	q.Set("client_id", clientID)
+	q.Set("redirect_uri", testRedirectURI)
+	q.Set("scope", scope)
+	q.Set("state", "xyz-state")
+	for k, vs := range extra {
+		for _, v := range vs {
+			q.Add(k, v)
+		}
+	}
+	return q
+}
+
+// loginForCode drives a full /oauth2/login POST (with the authQuery primed by a
+// prior GET) and returns the authorization code extracted from the redirect
+// Location, plus the cookies in play. It fails the test if no code is issued.
+//
+// The two-step GET-then-POST is required because the raw authorize query is
+// stashed in the login session by the GET handler and read back by the POST.
+func (ts *testServer) loginForCode(t *testing.T, q url.Values, login, password string) string {
+	t.Helper()
+
+	// Step 1: GET /oauth2/login?<authz query> — primes the session cookie.
+	getReq := newGet(t, "/oauth2/login?"+q.Encode())
+	getRR := ts.do(getReq)
+	cookies := readCookies(getRR)
+	if len(cookies) == 0 {
+		t.Fatalf("login GET set no session cookie (status %d)", getRR.Code)
+	}
+
+	// Step 2: POST credentials, carrying the session cookie back.
+	form := url.Values{}
+	form.Set("login", login)
+	form.Set("password", password)
+	postReq := newPostForm(t, "/oauth2/login", form)
+	for _, c := range cookies {
+		postReq.AddCookie(c)
+	}
+	postRR := ts.do(postReq)
+
+	if postRR.Code != http.StatusFound && postRR.Code != http.StatusSeeOther {
+		t.Fatalf("login POST: expected redirect, got %d body=%q", postRR.Code, postRR.Body.String())
+	}
+	loc := postRR.Header().Get("Location")
+	code := codeFromLocation(t, loc)
+	if code == "" {
+		t.Fatalf("login POST redirect carried no code: %q", loc)
+	}
+	return code
+}
+
+// exchangeCode posts an authorization_code grant to /oauth2/token and returns
+// the decoded JSON token response and the raw recorder.
+func (ts *testServer) exchangeCode(t *testing.T, code, clientID, clientSecret string, extra url.Values) (map[string]interface{}, *httptest.ResponseRecorder) {
+	t.Helper()
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", code)
+	form.Set("redirect_uri", testRedirectURI)
+	for k, vs := range extra {
+		for _, v := range vs {
+			form.Add(k, v)
+		}
+	}
+	req := newPostForm(t, "/oauth2/token", form)
+	if clientSecret != "" {
+		req.SetBasicAuth(clientID, clientSecret)
+	} else {
+		form.Set("client_id", clientID)
+		req = newPostForm(t, "/oauth2/token", form)
+	}
+	rr := ts.do(req)
+	out := map[string]interface{}{}
+	if rr.Body.Len() > 0 {
+		_ = json.Unmarshal(rr.Body.Bytes(), &out)
+	}
+	return out, rr
+}
+
+// ----------------------------------------------------------------- small utils
+
+func readCookies(rr *httptest.ResponseRecorder) []*http.Cookie {
+	res := &http.Response{Header: rr.Header()}
+	return res.Cookies()
+}
+
+// isRedirect reports whether the status is one of the 3xx codes fosite/the
+// handlers use for authorize redirects (302 Found or 303 See Other).
+func isRedirect(code int) bool {
+	return code == http.StatusFound || code == http.StatusSeeOther
+}
+
+func codeFromLocation(t *testing.T, loc string) string {
+	t.Helper()
+	if loc == "" {
+		return ""
+	}
+	u, err := url.Parse(loc)
+	if err != nil {
+		t.Fatalf("parse redirect location %q: %v", loc, err)
+	}
+	return u.Query().Get("code")
+}
+
+func decodeJSON(t *testing.T, rr *httptest.ResponseRecorder) map[string]interface{} {
+	t.Helper()
+	out := map[string]interface{}{}
+	if err := json.Unmarshal(rr.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode JSON (body=%q): %v", rr.Body.String(), err)
+	}
+	return out
+}
+
+// mustString fetches a string field or fails.
+func mustString(t *testing.T, m map[string]interface{}, key string) string {
+	t.Helper()
+	v, ok := m[key].(string)
+	if !ok || v == "" {
+		t.Fatalf("expected non-empty string field %q in %v", key, m)
+	}
+	return v
+}

--- a/cmd/oidc/oidcserver/handle_authorize_test.go
+++ b/cmd/oidc/oidcserver/handle_authorize_test.go
@@ -1,0 +1,197 @@
+/*
+Copyright (c) 2025 Kubotal.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package oidcserver
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"kubauth/cmd/oidc/authenticator"
+)
+
+var errBoom = errors.New("backend exploded")
+
+// ============================================ GET /oauth2/auth
+
+func TestAuthorize_ValidGet_RedirectsToLoginPreservingQuery(t *testing.T) {
+	ts := buildServer(t)
+
+	q := authzQuery(testClientID, "openid profile", nil)
+	rr := ts.do(newGet(t, "/oauth2/auth?"+q.Encode()))
+
+	if rr.Code != http.StatusFound {
+		t.Fatalf("status: got %d, want 302 body=%q", rr.Code, rr.Body.String())
+	}
+	loc := rr.Header().Get("Location")
+	u, err := url.Parse(loc)
+	if err != nil {
+		t.Fatalf("parse Location %q: %v", loc, err)
+	}
+	if u.Path != "/oauth2/login" {
+		t.Errorf("redirect path: got %q, want /oauth2/login", u.Path)
+	}
+	// The original authorize parameters must be carried over verbatim so the
+	// login step can rebuild the request.
+	for _, key := range []string{"client_id", "redirect_uri", "response_type", "scope", "state"} {
+		if u.Query().Get(key) != q.Get(key) {
+			t.Errorf("query %q not preserved: got %q, want %q", key, u.Query().Get(key), q.Get(key))
+		}
+	}
+}
+
+func TestAuthorize_UnknownClient_WritesAuthorizeError(t *testing.T) {
+	ts := buildServer(t)
+
+	q := authzQuery("no-such-client", "openid", nil)
+	rr := ts.do(newGet(t, "/oauth2/auth?"+q.Encode()))
+
+	// fosite rejects before the login redirect; an unknown client cannot be
+	// redirected to (untrusted redirect_uri), so the error is rendered locally.
+	if rr.Code == http.StatusFound {
+		// If it did redirect, it must NOT be to our login page with a valid flow.
+		if strings.Contains(rr.Header().Get("Location"), "/oauth2/login") {
+			t.Fatalf("unknown client should not reach the login page")
+		}
+	}
+	if rr.Code == http.StatusOK {
+		t.Fatalf("unknown client must not yield 200, body=%q", rr.Body.String())
+	}
+}
+
+func TestAuthorize_InvalidRedirectURI_DoesNotRedirectToLogin(t *testing.T) {
+	ts := buildServer(t)
+
+	q := authzQuery(testClientID, "openid", nil)
+	q.Set("redirect_uri", "https://attacker.test/cb") // not whitelisted
+	rr := ts.do(newGet(t, "/oauth2/auth?"+q.Encode()))
+
+	if rr.Code == http.StatusFound && strings.Contains(rr.Header().Get("Location"), "/oauth2/login") {
+		t.Fatalf("a non-whitelisted redirect_uri must be rejected, not forwarded to login")
+	}
+}
+
+func TestAuthorize_UnsupportedResponseType_IsRejected(t *testing.T) {
+	ts := buildServer(t)
+
+	q := authzQuery(testClientID, "openid", nil)
+	q.Set("response_type", "token") // client only allows "code"
+	rr := ts.do(newGet(t, "/oauth2/auth?"+q.Encode()))
+
+	if rr.Code == http.StatusFound && strings.Contains(rr.Header().Get("Location"), "/oauth2/login") {
+		t.Fatalf("unsupported response_type should not reach the login page")
+	}
+}
+
+// ============================================ method handling
+
+func TestAuthorize_PostMethod_NotAllowed(t *testing.T) {
+	ts := buildServer(t)
+
+	q := authzQuery(testClientID, "openid", nil)
+	// A POST that nonetheless parses as a valid authorize request hits the
+	// explicit method guard returning 405.
+	req := newPostForm(t, "/oauth2/auth", q)
+	rr := ts.do(req)
+
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("POST /oauth2/auth: got %d, want 405 body=%q", rr.Code, rr.Body.String())
+	}
+}
+
+// ============================================ login GET that fronts authorize
+
+func TestLogin_Get_RendersLoginForm(t *testing.T) {
+	// With no upstream providers configured, the default internal provider is
+	// used and the login form is shown.
+	ts := buildServer(t)
+
+	q := authzQuery(testClientID, "openid", nil)
+	rr := ts.do(newGet(t, "/oauth2/login?"+q.Encode()))
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("login GET: got %d, want 200 body=%q", rr.Code, rr.Body.String())
+	}
+	if ct := rr.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/html") {
+		t.Errorf("content-type: got %q, want text/html", ct)
+	}
+	if !strings.Contains(rr.Body.String(), "form=true") {
+		t.Errorf("expected login form to be shown, body=%q", rr.Body.String())
+	}
+}
+
+func TestLogin_Post_InvalidCredentials_RendersInvalidLogin(t *testing.T) {
+	ts := buildServer(t)
+
+	q := authzQuery(testClientID, "openid", nil)
+
+	// Prime the session via GET.
+	getRR := ts.do(newGet(t, "/oauth2/login?"+q.Encode()))
+	cookies := readCookies(getRR)
+
+	form := url.Values{}
+	form.Set("login", testUserLogin)
+	form.Set("password", "wrong-password")
+	postReq := newPostForm(t, "/oauth2/login", form)
+	for _, c := range cookies {
+		postReq.AddCookie(c)
+	}
+	rr := ts.do(postReq)
+
+	// Bad credentials => authenticator returns (nil, nil) => login page re-rendered.
+	if rr.Code != http.StatusOK {
+		t.Fatalf("invalid login: got %d, want 200 (re-render) body=%q", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "invalid=true") {
+		t.Errorf("expected invalid-login flag in rendered page, body=%q", rr.Body.String())
+	}
+}
+
+func TestLogin_Post_AuthenticatorError_Returns500(t *testing.T) {
+	ts := buildServer(t, func(o *buildOpts) {
+		o.auth = &fakeAuthenticator{
+			authFunc: func(_ context.Context, _, _ string) (*authenticator.OidcUser, error) {
+				return nil, errBoom
+			},
+		}
+	})
+
+	q := authzQuery(testClientID, "openid", nil)
+	getRR := ts.do(newGet(t, "/oauth2/login?"+q.Encode()))
+	cookies := readCookies(getRR)
+
+	form := url.Values{}
+	form.Set("login", testUserLogin)
+	form.Set("password", testUserPassword)
+	postReq := newPostForm(t, "/oauth2/login", form)
+	for _, c := range cookies {
+		postReq.AddCookie(c)
+	}
+	rr := ts.do(postReq)
+
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("authenticator error: got %d, want 500 body=%q", rr.Code, rr.Body.String())
+	}
+}
+
+func TestLogin_Post_NoSessionQuery_BadRequest(t *testing.T) {
+	ts := buildServer(t)
+
+	// POST without first doing the GET that stores authQuery in the session.
+	form := url.Values{}
+	form.Set("login", testUserLogin)
+	form.Set("password", testUserPassword)
+	rr := ts.do(newPostForm(t, "/oauth2/login", form))
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("missing session authQuery: got %d, want 400 body=%q", rr.Code, rr.Body.String())
+	}
+}

--- a/cmd/oidc/oidcserver/handle_authorize_test.go
+++ b/cmd/oidc/oidcserver/handle_authorize_test.go
@@ -74,8 +74,17 @@ func TestAuthorize_InvalidRedirectURI_DoesNotRedirectToLogin(t *testing.T) {
 	q.Set("redirect_uri", "https://attacker.test/cb") // not whitelisted
 	rr := ts.do(newGet(t, "/oauth2/auth?"+q.Encode()))
 
-	if rr.Code == http.StatusFound && strings.Contains(rr.Header().Get("Location"), "/oauth2/login") {
-		t.Fatalf("a non-whitelisted redirect_uri must be rejected, not forwarded to login")
+	// RFC 6749 4.1.2.1: an untrusted redirect_uri must NOT be redirected to.
+	// fosite reports the error locally (400 invalid_request), never forwarding
+	// the flow to the login page or to the attacker URL.
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want 400 body=%q", rr.Code, rr.Body.String())
+	}
+	if loc := rr.Header().Get("Location"); loc != "" {
+		t.Errorf("must not issue any redirect on an invalid redirect_uri, got Location %q", loc)
+	}
+	if !strings.Contains(rr.Body.String(), "invalid_request") {
+		t.Errorf("body should carry an invalid_request error, got %q", rr.Body.String())
 	}
 }
 
@@ -86,8 +95,20 @@ func TestAuthorize_UnsupportedResponseType_IsRejected(t *testing.T) {
 	q.Set("response_type", "token") // client only allows "code"
 	rr := ts.do(newGet(t, "/oauth2/auth?"+q.Encode()))
 
-	if rr.Code == http.StatusFound && strings.Contains(rr.Header().Get("Location"), "/oauth2/login") {
-		t.Fatalf("unsupported response_type should not reach the login page")
+	// The client and redirect_uri are valid, so fosite delivers the OAuth error
+	// to the REGISTERED redirect_uri (never the login page), per RFC 6749 4.1.2.1.
+	if rr.Code != http.StatusSeeOther && rr.Code != http.StatusFound {
+		t.Fatalf("status: got %d, want a 30x error redirect body=%q", rr.Code, rr.Body.String())
+	}
+	loc := rr.Header().Get("Location")
+	if strings.Contains(loc, "/oauth2/login") {
+		t.Fatalf("unsupported response_type must not reach the login page, Location=%q", loc)
+	}
+	if !strings.HasPrefix(loc, q.Get("redirect_uri")) {
+		t.Errorf("error must be delivered to the registered redirect_uri %q, got %q", q.Get("redirect_uri"), loc)
+	}
+	if !strings.Contains(loc, "error=unsupported_response_type") {
+		t.Errorf("redirect should carry error=unsupported_response_type, got %q", loc)
 	}
 }
 

--- a/cmd/oidc/oidcserver/handle_introspection_test.go
+++ b/cmd/oidc/oidcserver/handle_introspection_test.go
@@ -63,17 +63,15 @@ func TestIntrospect_NoClientAuth_NonPublicPath_Errors(t *testing.T) {
 	accessToken := ts.accessTokenForUser(t, "openid")
 
 	// No Authorization header and the body client_id is a confidential client,
-	// so the public-client fast path is not taken and fosite rejects it.
+	// so the public-client fast path is not taken and fosite must reject the
+	// request outright: a confidential client cannot introspect unauthenticated.
 	form := url.Values{}
 	form.Set("token", accessToken)
 	form.Set("client_id", testClientID) // confidential, not public
 	rr := ts.do(newPostForm(t, "/oauth2/introspect", form))
 
-	if rr.Code == http.StatusOK {
-		body := decodeJSON(t, rr)
-		if active, _ := body["active"].(bool); active {
-			t.Fatalf("confidential client without auth must not get an active introspection")
-		}
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("confidential client without auth: got %d, want 401 body=%q", rr.Code, rr.Body.String())
 	}
 }
 

--- a/cmd/oidc/oidcserver/handle_introspection_test.go
+++ b/cmd/oidc/oidcserver/handle_introspection_test.go
@@ -1,0 +1,132 @@
+/*
+Copyright (c) 2025 Kubotal.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package oidcserver
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"kubauth/cmd/oidc/oidcstorage"
+)
+
+// ============================================ confidential client introspection
+
+func TestIntrospect_ActiveToken_ConfidentialClient(t *testing.T) {
+	ts := buildServer(t)
+	accessToken := ts.accessTokenForUser(t, "openid email")
+
+	form := url.Values{}
+	form.Set("token", accessToken)
+	req := newPostForm(t, "/oauth2/introspect", form)
+	req.SetBasicAuth(testClientID, testClientSecret) // confidential client auth
+	rr := ts.do(req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("introspect: got %d body=%q", rr.Code, rr.Body.String())
+	}
+	body := decodeJSON(t, rr)
+	if active, _ := body["active"].(bool); !active {
+		t.Fatalf("expected active=true for a freshly issued token, got %v", body)
+	}
+	if sub, _ := body["sub"].(string); sub != testUserLogin {
+		t.Errorf("introspection sub: got %q, want %q", sub, testUserLogin)
+	}
+}
+
+func TestIntrospect_InvalidToken_ConfidentialClient_ReturnsInactive(t *testing.T) {
+	ts := buildServer(t)
+
+	form := url.Values{}
+	form.Set("token", "definitely-not-valid")
+	req := newPostForm(t, "/oauth2/introspect", form)
+	req.SetBasicAuth(testClientID, testClientSecret)
+	rr := ts.do(req)
+
+	// RFC 7662: an unknown but well-formed request returns active=false, 200.
+	if rr.Code != http.StatusOK {
+		t.Fatalf("introspect invalid token: got %d body=%q", rr.Code, rr.Body.String())
+	}
+	body := decodeJSON(t, rr)
+	if active, _ := body["active"].(bool); active {
+		t.Errorf("invalid token must be reported inactive, got %v", body)
+	}
+}
+
+func TestIntrospect_NoClientAuth_NonPublicPath_Errors(t *testing.T) {
+	ts := buildServer(t)
+	accessToken := ts.accessTokenForUser(t, "openid")
+
+	// No Authorization header and the body client_id is a confidential client,
+	// so the public-client fast path is not taken and fosite rejects it.
+	form := url.Values{}
+	form.Set("token", accessToken)
+	form.Set("client_id", testClientID) // confidential, not public
+	rr := ts.do(newPostForm(t, "/oauth2/introspect", form))
+
+	if rr.Code == http.StatusOK {
+		body := decodeJSON(t, rr)
+		if active, _ := body["active"].(bool); active {
+			t.Fatalf("confidential client without auth must not get an active introspection")
+		}
+	}
+}
+
+// ============================================ public client introspection path
+
+func TestIntrospect_PublicClient_ActiveToken(t *testing.T) {
+	// Register a public client and mint a token for it via PKCE-less code flow.
+	// The public client allows code flow; we drive it through the login helper.
+	ts := buildServer(t, func(o *buildOpts) {
+		o.clients = []oidcstorage.KubauthClient{confidentialClient(t), publicClient(t)}
+	})
+
+	// Mint an access token for the PUBLIC client (no client secret at token endpoint).
+	q := authzQuery(testPublicClient, "openid", nil)
+	code := ts.loginForCode(t, q, testUserLogin, testUserPassword)
+	tokens, rr := ts.exchangeCode(t, code, testPublicClient, "", nil) // public: client_id in body, no secret
+	if rr.Code != http.StatusOK {
+		t.Fatalf("public client token exchange: got %d body=%q", rr.Code, rr.Body.String())
+	}
+	accessToken := mustString(t, tokens, "access_token")
+
+	// Introspect via the public-client branch: no Authorization header,
+	// client_id + token in the form body.
+	form := url.Values{}
+	form.Set("client_id", testPublicClient)
+	form.Set("token", accessToken)
+	form.Set("token_type_hint", "access_token")
+	rr2 := ts.do(newPostForm(t, "/oauth2/introspect", form))
+
+	if rr2.Code != http.StatusOK {
+		t.Fatalf("public introspect: got %d body=%q", rr2.Code, rr2.Body.String())
+	}
+	body := decodeJSON(t, rr2)
+	if active, _ := body["active"].(bool); !active {
+		t.Fatalf("public client active token must introspect as active, got %v", body)
+	}
+}
+
+func TestIntrospect_PublicClient_InvalidToken_ReturnsInactiveJSON(t *testing.T) {
+	ts := buildServer(t, func(o *buildOpts) {
+		o.clients = []oidcstorage.KubauthClient{publicClient(t)}
+	})
+
+	form := url.Values{}
+	form.Set("client_id", testPublicClient)
+	form.Set("token", "garbage-token")
+	rr := ts.do(newPostForm(t, "/oauth2/introspect", form))
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("public introspect invalid: got %d body=%q", rr.Code, rr.Body.String())
+	}
+	body := decodeJSON(t, rr)
+	if active, _ := body["active"].(bool); active {
+		t.Errorf("invalid token for public client must be inactive, got %v", body)
+	}
+}

--- a/cmd/oidc/oidcserver/handle_login_sso_test.go
+++ b/cmd/oidc/oidcserver/handle_login_sso_test.go
@@ -1,0 +1,183 @@
+/*
+Copyright (c) 2025 Kubotal.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package oidcserver
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"kubauth/cmd/oidc/authenticator"
+)
+
+// ============================================ SSO session reuse
+
+// When SSO is active (the user previously logged in with "remember"), a second
+// authorize/login GET must complete the flow directly (302 with a code) without
+// re-prompting for credentials. This exercises handleLogin's SSO-reuse branch,
+// which round-trips the stored user through the JSON codec into a
+// map[string]interface{}.
+func TestLogin_SsoReuse_CompletesWithoutPasswordPrompt(t *testing.T) {
+	ts := buildServer(t, func(o *buildOpts) { o.ssoMode = SsoOnDemand })
+
+	q := authzQuery(testClientID, "openid profile", nil)
+
+	// First login: GET to prime session, POST with remember=on to persist SSO.
+	getRR := ts.do(newGet(t, "/oauth2/login?"+q.Encode()))
+	cookies := readCookies(getRR)
+
+	form := url.Values{}
+	form.Set("login", testUserLogin)
+	form.Set("password", testUserPassword)
+	form.Set("remember", "on")
+	postReq := newPostForm(t, "/oauth2/login", form)
+	for _, c := range cookies {
+		postReq.AddCookie(c)
+	}
+	postRR := ts.do(postReq)
+	if !isRedirect(postRR.Code) {
+		t.Fatalf("first login should redirect with a code, got %d body=%q", postRR.Code, postRR.Body.String())
+	}
+	if codeFromLocation(t, postRR.Header().Get("Location")) == "" {
+		t.Fatalf("first login carried no code: %q", postRR.Header().Get("Location"))
+	}
+
+	// Carry forward all cookies set across the two responses (login + sso).
+	sessionCookies := mergeCookies(cookies, readCookies(postRR))
+
+	// Second authorize: a plain GET /oauth2/login with the SSO cookie must
+	// complete immediately (no form), returning a fresh code.
+	secondReq := newGet(t, "/oauth2/login?"+q.Encode())
+	for _, c := range sessionCookies {
+		secondReq.AddCookie(c)
+	}
+	secondRR := ts.do(secondReq)
+
+	if !isRedirect(secondRR.Code) {
+		t.Fatalf("SSO reuse must redirect (no password prompt), got %d body=%q", secondRR.Code, secondRR.Body.String())
+	}
+	loc := secondRR.Header().Get("Location")
+	if code := codeFromLocation(t, loc); code == "" {
+		t.Fatalf("SSO reuse must yield an authorization code, location=%q", loc)
+	}
+	if u, _ := url.Parse(loc); u != nil && u.Path == "/oauth2/login" {
+		t.Errorf("SSO reuse must not bounce back to the login page: %q", loc)
+	}
+}
+
+// Without remember (onDemand) the SSO user is not persisted, so a second GET
+// must fall back to rendering the login form rather than completing silently.
+func TestLogin_OnDemandNoRemember_DoesNotPersistSso(t *testing.T) {
+	ts := buildServer(t, func(o *buildOpts) { o.ssoMode = SsoOnDemand })
+
+	q := authzQuery(testClientID, "openid", nil)
+	getRR := ts.do(newGet(t, "/oauth2/login?"+q.Encode()))
+	cookies := readCookies(getRR)
+
+	form := url.Values{}
+	form.Set("login", testUserLogin)
+	form.Set("password", testUserPassword)
+	// remember intentionally omitted
+	postReq := newPostForm(t, "/oauth2/login", form)
+	for _, c := range cookies {
+		postReq.AddCookie(c)
+	}
+	postRR := ts.do(postReq)
+	if !isRedirect(postRR.Code) {
+		t.Fatalf("login should still succeed for this request, got %d", postRR.Code)
+	}
+
+	sessionCookies := mergeCookies(cookies, readCookies(postRR))
+	secondReq := newGet(t, "/oauth2/login?"+q.Encode())
+	for _, c := range sessionCookies {
+		secondReq.AddCookie(c)
+	}
+	secondRR := ts.do(secondReq)
+
+	// No persisted SSO => login form is rendered (200), not a silent redirect.
+	if secondRR.Code != http.StatusOK {
+		t.Fatalf("without remember, second GET should render the form (200), got %d", secondRR.Code)
+	}
+	if !strings.Contains(secondRR.Body.String(), "form=true") {
+		t.Errorf("expected the login form to be re-rendered, body=%q", secondRR.Body.String())
+	}
+}
+
+// ============================================ newSession unit
+
+func TestNewSession_PopulatesClaimsAndAzp(t *testing.T) {
+	ts := buildServer(t)
+	user := &authenticator.OidcUser{
+		Login:    testUserLogin,
+		FullName: "Alice Example",
+		Claims: map[string]interface{}{
+			"sub":   testUserLogin,
+			"email": "alice@test",
+		},
+	}
+	sess := ts.srv.newSession(user, testClientID)
+
+	if sess.Subject != testUserLogin {
+		t.Errorf("session subject: got %q, want %q", sess.Subject, testUserLogin)
+	}
+	if sess.IDTokenClaims_ == nil || sess.JWTClaims_ == nil {
+		t.Fatal("newSession must initialise both ID and JWT claim containers")
+	}
+	if sess.IDTokenClaims_.Subject != testUserLogin {
+		t.Errorf("id token subject: got %q", sess.IDTokenClaims_.Subject)
+	}
+	if got := sess.IDTokenClaims_.Issuer; got != testIssuer {
+		t.Errorf("id token issuer: got %q, want %q", got, testIssuer)
+	}
+	// azp is added for a non-empty client id.
+	if azp, _ := sess.IDTokenClaims_.Extra["azp"].(string); azp != testClientID {
+		t.Errorf("azp: got %q, want %q", azp, testClientID)
+	}
+	// kid header must be set from the server key id.
+	if kid, _ := sess.Headers.Extra["kid"].(string); kid != ts.kid {
+		t.Errorf("session header kid: got %q, want %q", kid, ts.kid)
+	}
+}
+
+func TestNewSession_NilUser_EmptySubject_NoAzpForEmptyClient(t *testing.T) {
+	ts := buildServer(t)
+	sess := ts.srv.newSession(nil, "")
+
+	if sess.Subject != "" {
+		t.Errorf("nil user should give empty subject, got %q", sess.Subject)
+	}
+	if _, ok := sess.IDTokenClaims_.Extra["azp"]; ok {
+		t.Error("azp must not be added for an empty client id")
+	}
+	// Expiry on the JWT claims must reflect AccessTokenLifespan.
+	if sess.JWTClaims_.ExpiresAt.Before(time.Now()) {
+		t.Error("JWT claims ExpiresAt should be in the future")
+	}
+}
+
+// ----------------------------------------------------------------- helpers
+
+func mergeCookies(sets ...[]*http.Cookie) []*http.Cookie {
+	byName := map[string]*http.Cookie{}
+	var order []string
+	for _, set := range sets {
+		for _, c := range set {
+			if _, seen := byName[c.Name]; !seen {
+				order = append(order, c.Name)
+			}
+			byName[c.Name] = c // later sets override earlier (fresher value)
+		}
+	}
+	out := make([]*http.Cookie, 0, len(order))
+	for _, n := range order {
+		out = append(out, byName[n])
+	}
+	return out
+}

--- a/cmd/oidc/oidcserver/handle_metadata_test.go
+++ b/cmd/oidc/oidcserver/handle_metadata_test.go
@@ -1,0 +1,186 @@
+/*
+Copyright (c) 2025 Kubotal.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package oidcserver
+
+import (
+	"crypto/rsa"
+	"encoding/base64"
+	"math/big"
+	"net/http"
+	"testing"
+)
+
+// ============================================================ JWKS endpoint
+
+func TestJWKS_ReturnsSingleKeyMatchingSigningKey(t *testing.T) {
+	ts := buildServer(t)
+
+	rr := ts.do(newGet(t, "/.well-known/jwks.json"))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", rr.Code)
+	}
+	if ct := rr.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("content-type: got %q", ct)
+	}
+
+	body := decodeJSON(t, rr)
+	keysAny, ok := body["keys"].([]interface{})
+	if !ok || len(keysAny) != 1 {
+		t.Fatalf("expected exactly one key, got %v", body["keys"])
+	}
+	jwk, ok := keysAny[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("key is not an object: %T", keysAny[0])
+	}
+
+	// Static metadata.
+	for k, want := range map[string]string{"kty": "RSA", "use": "sig", "alg": "RS256"} {
+		if got, _ := jwk[k].(string); got != want {
+			t.Errorf("jwk[%q]: got %q, want %q", k, got, want)
+		}
+	}
+	// kid must equal the kid loaded from the secret (deterministic in the fixture).
+	if got, _ := jwk["kid"].(string); got != ts.kid {
+		t.Errorf("kid: got %q, want %q", got, ts.kid)
+	}
+
+	// The n/e components must reconstruct the fixture's public key exactly.
+	pub := ts.key.Public().(*rsa.PublicKey)
+	wantN := base64.RawURLEncoding.EncodeToString(pub.N.Bytes())
+	wantE := base64.RawURLEncoding.EncodeToString(big.NewInt(int64(pub.E)).Bytes())
+	if got, _ := jwk["n"].(string); got != wantN {
+		t.Errorf("modulus n mismatch\n got %s\nwant %s", got, wantN)
+	}
+	if got, _ := jwk["e"].(string); got != wantE {
+		t.Errorf("exponent e mismatch: got %q, want %q", got, wantE)
+	}
+
+	// And the decoded n must equal the real modulus (defends against a future
+	// encoding change that round-trips through base64 but corrupts the number).
+	nDecoded, err := base64.RawURLEncoding.DecodeString(jwk["n"].(string))
+	if err != nil {
+		t.Fatalf("decode n: %v", err)
+	}
+	if new(big.Int).SetBytes(nDecoded).Cmp(pub.N) != 0 {
+		t.Error("decoded modulus does not equal the signing key modulus")
+	}
+}
+
+// ====================================================== OIDC configuration
+
+func TestOpenIDConfiguration_CoreEndpointsDerivedFromIssuer(t *testing.T) {
+	ts := buildServer(t)
+
+	rr := ts.do(newGet(t, "/.well-known/openid-configuration"))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", rr.Code)
+	}
+	if ct := rr.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("content-type: got %q", ct)
+	}
+
+	cfg := decodeJSON(t, rr)
+	wantEndpoints := map[string]string{
+		"issuer":                 testIssuer,
+		"authorization_endpoint": testIssuer + "/oauth2/auth",
+		"token_endpoint":         testIssuer + "/oauth2/token",
+		"userinfo_endpoint":      testIssuer + "/userinfo",
+		"end_session_endpoint":   testIssuer + "/oauth2/logout",
+		"jwks_uri":               testIssuer + "/.well-known/jwks.json",
+		"introspection_endpoint": testIssuer + "/oauth2/introspect",
+	}
+	for k, want := range wantEndpoints {
+		if got, _ := cfg[k].(string); got != want {
+			t.Errorf("%s: got %q, want %q", k, got, want)
+		}
+	}
+	if got, _ := cfg["id_token_signing_alg_values_supported"].([]interface{}); len(got) != 1 || got[0] != "RS256" {
+		t.Errorf("signing algs: got %v, want [RS256]", cfg["id_token_signing_alg_values_supported"])
+	}
+}
+
+func TestOpenIDConfiguration_GrantTypesOmitPasswordByDefault(t *testing.T) {
+	ts := buildServer(t) // AllowPasswordGrant defaults to false
+
+	cfg := decodeJSON(t, ts.do(newGet(t, "/.well-known/openid-configuration")))
+	if containsString(toStrings(cfg["grant_types_supported"]), "password") {
+		t.Errorf("password grant must not be advertised when disabled: %v", cfg["grant_types_supported"])
+	}
+}
+
+func TestOpenIDConfiguration_GrantTypesIncludePasswordWhenEnabled(t *testing.T) {
+	ts := buildServer(t, func(o *buildOpts) { o.allowPasswordGrant = true })
+
+	cfg := decodeJSON(t, ts.do(newGet(t, "/.well-known/openid-configuration")))
+	if !containsString(toStrings(cfg["grant_types_supported"]), "password") {
+		t.Errorf("password grant must be advertised when enabled: %v", cfg["grant_types_supported"])
+	}
+}
+
+func TestOpenIDConfiguration_PKCEMethods_S256Only_ByDefault(t *testing.T) {
+	ts := buildServer(t) // AllowPKCEPlain defaults to false
+
+	cfg := decodeJSON(t, ts.do(newGet(t, "/.well-known/openid-configuration")))
+	methods := toStrings(cfg["code_challenge_methods_supported"])
+	if !containsString(methods, "S256") {
+		t.Errorf("S256 must always be supported, got %v", methods)
+	}
+	if containsString(methods, "plain") {
+		t.Errorf("plain must not be advertised when not allowed, got %v", methods)
+	}
+}
+
+func TestOpenIDConfiguration_PKCEMethods_IncludePlainWhenAllowed(t *testing.T) {
+	ts := buildServer(t)
+	ts.srv.AllowPKCEPlain = true // getSupportedPKCEMethods reads this field directly
+
+	cfg := decodeJSON(t, ts.do(newGet(t, "/.well-known/openid-configuration")))
+	methods := toStrings(cfg["code_challenge_methods_supported"])
+	if !containsString(methods, "plain") || !containsString(methods, "S256") {
+		t.Errorf("expected both S256 and plain, got %v", methods)
+	}
+}
+
+// getSupportedPKCEMethods is exercised indirectly above, but the unit-level
+// branch is asserted here for clarity and to pin the "always S256" invariant.
+func TestGetSupportedPKCEMethods_Unit(t *testing.T) {
+	s := &OIDCServer{AllowPKCEPlain: false}
+	if got := s.getSupportedPKCEMethods(); len(got) != 1 || got[0] != "S256" {
+		t.Errorf("disabled: got %v, want [S256]", got)
+	}
+	s.AllowPKCEPlain = true
+	got := s.getSupportedPKCEMethods()
+	if len(got) != 2 || got[0] != "S256" || got[1] != "plain" {
+		t.Errorf("enabled: got %v, want [S256 plain]", got)
+	}
+}
+
+// ----------------------------------------------------------------- helpers
+
+func toStrings(v interface{}) []string {
+	arr, ok := v.([]interface{})
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(arr))
+	for _, e := range arr {
+		if s, ok := e.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func containsString(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/oidc/oidcserver/handle_misc_test.go
+++ b/cmd/oidc/oidcserver/handle_misc_test.go
@@ -1,0 +1,227 @@
+/*
+Copyright (c) 2025 Kubotal.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package oidcserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"kubauth/api/kubauth/v1alpha1"
+	"kubauth/cmd/oidc/authenticator"
+	"kubauth/cmd/oidc/oidcstorage"
+)
+
+// ============================================ /oauth2/logout
+
+func TestLogout_DefaultRedirect_WhenNoClientOrParam(t *testing.T) {
+	ts := buildServer(t)
+
+	rr := ts.do(newGet(t, "/oauth2/logout"))
+	if rr.Code != http.StatusFound {
+		t.Fatalf("logout: got %d, want 302 body=%q", rr.Code, rr.Body.String())
+	}
+	if loc := rr.Header().Get("Location"); loc != ts.srv.PostLogoutURL {
+		t.Errorf("logout redirect: got %q, want default %q", loc, ts.srv.PostLogoutURL)
+	}
+}
+
+func TestLogout_QueryParamOverridesDefault(t *testing.T) {
+	ts := buildServer(t)
+
+	target := "https://elsewhere.test/bye"
+	q := url.Values{}
+	q.Set("post_logout_redirect_uri", target)
+	rr := ts.do(newGet(t, "/oauth2/logout?"+q.Encode()))
+
+	if loc := rr.Header().Get("Location"); loc != target {
+		t.Errorf("query param must take precedence: got %q, want %q", loc, target)
+	}
+}
+
+func TestLogout_ClientPostLogoutURLUsedWhenSet(t *testing.T) {
+	ts := buildServer(t) // confidentialClient has no PostLogoutURL; set one on a fresh client.
+
+	// The default confidential client has an empty PostLogoutURL, so the
+	// global default applies. Verify a client WITH a PostLogoutURL overrides it.
+	q := url.Values{}
+	q.Set("client_id", testClientID)
+	rr := ts.do(newGet(t, "/oauth2/logout?"+q.Encode()))
+
+	// confidentialClient has empty PostLogoutURL => falls back to global default.
+	if loc := rr.Header().Get("Location"); loc != ts.srv.PostLogoutURL {
+		t.Errorf("client without PostLogoutURL should use global default: got %q", loc)
+	}
+}
+
+func TestLogout_ClientSpecificPostLogoutURL(t *testing.T) {
+	// Build a server whose single client defines a PostLogoutURL.
+	ts := buildServer(t)
+	clientLogout := "https://app.test/after-logout"
+
+	// Replace the stored client with one carrying a PostLogoutURL.
+	k8s := confidentialClient(t).GetK8sObject()
+	k8s.Spec.PostLogoutURL = clientLogout
+	if err := ts.store.SetClient(testCtx(), wrapClient(k8s)); err != nil {
+		t.Fatalf("SetClient: %v", err)
+	}
+
+	q := url.Values{}
+	q.Set("client_id", testClientID)
+	rr := ts.do(newGet(t, "/oauth2/logout?"+q.Encode()))
+	if loc := rr.Header().Get("Location"); loc != clientLogout {
+		t.Errorf("client PostLogoutURL must be used: got %q, want %q", loc, clientLogout)
+	}
+}
+
+// ============================================ /index
+
+func TestIndex_ListsClientsWithNameAndEntryURL(t *testing.T) {
+	ts := buildServer(t) // confidentialClient has DisplayName + EntryURL
+
+	rr := ts.do(newGet(t, "/index"))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("index: got %d body=%q", rr.Code, rr.Body.String())
+	}
+	if ct := rr.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/html") {
+		// handleIndex relies on the template; default content type is text/html.
+		t.Logf("index content-type: %q", ct)
+	}
+	body := rr.Body.String()
+	if !strings.Contains(body, "app:Web App|https://app.test/") {
+		t.Errorf("index should list the web app entry, body=%q", body)
+	}
+}
+
+func TestIndex_OmitsClientsMissingDisplayNameOrEntryURL(t *testing.T) {
+	// A client without EntryURL must not appear.
+	noEntry := confidentialClient(t).GetK8sObject()
+	noEntry.Name = "no-entry"
+	noEntry.Spec.EntryURL = ""
+	noEntry.Spec.DisplayName = "No Entry App"
+
+	ts := buildServer(t)
+	if err := ts.store.SetClient(testCtx(), wrapNamed(noEntry, "no-entry")); err != nil {
+		t.Fatalf("SetClient: %v", err)
+	}
+
+	body := ts.do(newGet(t, "/index")).Body.String()
+	if strings.Contains(body, "No Entry App") {
+		t.Errorf("client without EntryURL must be excluded, body=%q", body)
+	}
+}
+
+// ============================================ GetClientIdFromRequest
+
+func TestGetClientIdFromRequest_FromForm(t *testing.T) {
+	form := url.Values{}
+	form.Set("client_id", "abc-123")
+	req := httptest.NewRequest(http.MethodPost, "/x", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	if got := GetClientIdFromRequest(req); got != "abc-123" {
+		t.Errorf("got %q, want abc-123", got)
+	}
+}
+
+func TestGetClientIdFromRequest_FromQuery(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/x?client_id=q-client", nil)
+	if got := GetClientIdFromRequest(req); got != "q-client" {
+		t.Errorf("got %q, want q-client", got)
+	}
+}
+
+func TestGetClientIdFromRequest_AbsentReturnsEmpty(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	if got := GetClientIdFromRequest(req); got != "" {
+		t.Errorf("got %q, want empty", got)
+	}
+}
+
+// ============================================ clientIDFromRawQuery (pure)
+
+func TestClientIDFromRawQuery(t *testing.T) {
+	cases := []struct {
+		name, raw, want string
+	}{
+		{"empty", "", ""},
+		{"present", "client_id=foo&scope=openid", "foo"},
+		{"absent", "scope=openid&state=x", ""},
+		{"url-encoded", "client_id=a%20b", "a b"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := clientIDFromRawQuery(tc.raw); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// ============================================ welcomeUserName (pure)
+
+func TestWelcomeUserName_Precedence(t *testing.T) {
+	cases := []struct {
+		name string
+		user *authenticator.OidcUser
+		want string
+	}{
+		{"nil user", nil, ""},
+		{
+			"fullName wins",
+			&authenticator.OidcUser{FullName: "Full Name", Claims: map[string]interface{}{"name": "claim name"}, Login: "login"},
+			"Full Name",
+		},
+		{
+			"name claim next",
+			&authenticator.OidcUser{Claims: map[string]interface{}{"name": "Claim Name"}, Login: "login"},
+			"Claim Name",
+		},
+		{
+			"preferred_username before email",
+			&authenticator.OidcUser{Claims: map[string]interface{}{"preferred_username": "pref", "email": "e@x"}, Login: "login"},
+			"pref",
+		},
+		{
+			"given + family combined",
+			&authenticator.OidcUser{Claims: map[string]interface{}{"given_name": "Jane", "family_name": "Doe"}, Login: "login"},
+			"Jane Doe",
+		},
+		{
+			"given only",
+			&authenticator.OidcUser{Claims: map[string]interface{}{"given_name": "Solo"}, Login: "login"},
+			"Solo",
+		},
+		{
+			"falls back to login",
+			&authenticator.OidcUser{Login: "  fallback-login  "},
+			"fallback-login",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := welcomeUserName(tc.user); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// ----------------------------------------------------------------- helpers
+
+// wrapClient rebuilds a KubauthClient around an edited CR, keyed by the CR name
+// as client_id. wrapNamed lets the caller pass an explicit client_id.
+func wrapClient(k8s *v1alpha1.OidcClient) oidcstorage.KubauthClient {
+	return wrapNamed(k8s, k8s.GetName())
+}
+
+func wrapNamed(k8s *v1alpha1.OidcClient, clientID string) oidcstorage.KubauthClient {
+	return oidcstorage.NewKubauthClient(k8s, clientID, nil)
+}

--- a/cmd/oidc/oidcserver/handle_token_test.go
+++ b/cmd/oidc/oidcserver/handle_token_test.go
@@ -1,0 +1,341 @@
+/*
+Copyright (c) 2025 Kubotal.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package oidcserver
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/go-jose/go-jose/v3/jwt"
+)
+
+// ============================================ authorization_code happy path
+
+func TestToken_AuthorizationCode_IssuesTokensAndIDToken(t *testing.T) {
+	ts := buildServer(t)
+
+	q := authzQuery(testClientID, "openid profile email groups", nil)
+	code := ts.loginForCode(t, q, testUserLogin, testUserPassword)
+
+	tokens, rr := ts.exchangeCode(t, code, testClientID, testClientSecret, nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("token endpoint: got %d body=%q", rr.Code, rr.Body.String())
+	}
+
+	accessToken := mustString(t, tokens, "access_token")
+	if tt, _ := tokens["token_type"].(string); !strings.EqualFold(tt, "bearer") {
+		t.Errorf("token_type: got %q, want bearer", tt)
+	}
+	if _, ok := tokens["expires_in"]; !ok {
+		t.Error("expires_in missing from token response")
+	}
+
+	// openid scope requested => an ID token must be present and well-formed.
+	rawID := mustString(t, tokens, "id_token")
+	claims := parseSignedClaims(t, ts, rawID)
+	if sub, _ := claims["sub"].(string); sub != testUserLogin {
+		t.Errorf("id_token sub: got %q, want %q", sub, testUserLogin)
+	}
+	if iss, _ := claims["iss"].(string); iss != testIssuer {
+		t.Errorf("id_token iss: got %q, want %q", iss, testIssuer)
+	}
+	if aud := claims["aud"]; !audienceContains(aud, testClientID) {
+		t.Errorf("id_token aud must contain client id, got %v", aud)
+	}
+	// azp is added by newSession for non-empty client id.
+	if azp, _ := claims["azp"].(string); azp != testClientID {
+		t.Errorf("id_token azp: got %q, want %q", azp, testClientID)
+	}
+	// Mapped user claims must propagate into the ID token.
+	if email, _ := claims["email"].(string); email != "alice@test" {
+		t.Errorf("id_token email: got %q", email)
+	}
+
+	if accessToken == "" {
+		t.Error("empty access token")
+	}
+}
+
+func TestToken_AuthorizationCode_IDTokenSignatureVerifiesAgainstJWKS(t *testing.T) {
+	ts := buildServer(t)
+
+	q := authzQuery(testClientID, "openid", nil)
+	code := ts.loginForCode(t, q, testUserLogin, testUserPassword)
+	tokens, rr := ts.exchangeCode(t, code, testClientID, testClientSecret, nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("token endpoint failed: %d %q", rr.Code, rr.Body.String())
+	}
+	rawID := mustString(t, tokens, "id_token")
+
+	// Parsing with the public key is the real signature check.
+	tok, err := jwt.ParseSigned(rawID)
+	if err != nil {
+		t.Fatalf("parse id_token: %v", err)
+	}
+	out := map[string]interface{}{}
+	if err := tok.Claims(ts.key.Public(), &out); err != nil {
+		t.Fatalf("id_token signature verification failed: %v", err)
+	}
+	// Header kid must point at the advertised JWKS kid.
+	if len(tok.Headers) == 0 || tok.Headers[0].KeyID != ts.kid {
+		t.Errorf("id_token kid header: got %+v, want %q", tok.Headers, ts.kid)
+	}
+}
+
+// ============================================ refresh_token grant
+
+func TestToken_RefreshToken_RotatesAndReturnsNewAccessToken(t *testing.T) {
+	ts := buildServer(t)
+
+	// offline_access (or offline scope) is required for a refresh token.
+	q := authzQuery(testClientID, "openid offline", nil)
+	code := ts.loginForCode(t, q, testUserLogin, testUserPassword)
+	tokens, rr := ts.exchangeCode(t, code, testClientID, testClientSecret, nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("initial exchange failed: %d %q", rr.Code, rr.Body.String())
+	}
+	refreshToken := mustString(t, tokens, "refresh_token")
+	firstAccess := mustString(t, tokens, "access_token")
+
+	// Now redeem the refresh token.
+	form := url.Values{}
+	form.Set("grant_type", "refresh_token")
+	form.Set("refresh_token", refreshToken)
+	form.Set("scope", "openid offline")
+	req := newPostForm(t, "/oauth2/token", form)
+	req.SetBasicAuth(testClientID, testClientSecret)
+	rr2 := ts.do(req)
+	if rr2.Code != http.StatusOK {
+		t.Fatalf("refresh exchange: got %d body=%q", rr2.Code, rr2.Body.String())
+	}
+	refreshed := decodeJSON(t, rr2)
+	newAccess := mustString(t, refreshed, "access_token")
+	if newAccess == firstAccess {
+		t.Error("refresh should mint a different access token")
+	}
+	if _, ok := refreshed["id_token"]; !ok {
+		t.Error("refresh with openid scope should return a fresh id_token")
+	}
+}
+
+func TestToken_RefreshToken_OldTokenInvalidAfterRotation(t *testing.T) {
+	ts := buildServer(t)
+
+	q := authzQuery(testClientID, "openid offline", nil)
+	code := ts.loginForCode(t, q, testUserLogin, testUserPassword)
+	tokens, _ := ts.exchangeCode(t, code, testClientID, testClientSecret, nil)
+	refreshToken := mustString(t, tokens, "refresh_token")
+
+	redeem := func() *http.Response {
+		form := url.Values{}
+		form.Set("grant_type", "refresh_token")
+		form.Set("refresh_token", refreshToken)
+		req := newPostForm(t, "/oauth2/token", form)
+		req.SetBasicAuth(testClientID, testClientSecret)
+		return ts.do(req).Result()
+	}
+
+	res1 := redeem()
+	defer func() { _ = res1.Body.Close() }()
+	if res1.StatusCode != http.StatusOK {
+		t.Fatalf("first refresh redemption should succeed, got %d", res1.StatusCode)
+	}
+	// Reusing the same (now-rotated) refresh token must fail.
+	res2 := redeem()
+	defer func() { _ = res2.Body.Close() }()
+	if res2.StatusCode == http.StatusOK {
+		t.Error("reusing a rotated refresh token must not succeed")
+	}
+}
+
+// ============================================ client_credentials grant
+
+func TestToken_ClientCredentials_GrantsConfiguredScopes(t *testing.T) {
+	ts := buildServer(t)
+
+	form := url.Values{}
+	form.Set("grant_type", "client_credentials")
+	form.Set("scope", "openid profile")
+	req := newPostForm(t, "/oauth2/token", form)
+	req.SetBasicAuth(testClientID, testClientSecret)
+
+	rr := ts.do(req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("client_credentials: got %d body=%q", rr.Code, rr.Body.String())
+	}
+	tokens := decodeJSON(t, rr)
+	if _, ok := tokens["access_token"].(string); !ok {
+		t.Errorf("client_credentials must return an access_token, got %v", tokens)
+	}
+	// client_credentials is not a user flow: no id_token.
+	if _, ok := tokens["id_token"]; ok {
+		t.Error("client_credentials must not return an id_token")
+	}
+}
+
+// ============================================ error paths
+
+func TestToken_UnknownClient_ReturnsInvalidClient(t *testing.T) {
+	ts := buildServer(t)
+
+	form := url.Values{}
+	form.Set("grant_type", "client_credentials")
+	req := newPostForm(t, "/oauth2/token", form)
+	req.SetBasicAuth("ghost-client", "whatever")
+
+	rr := ts.do(req)
+	if rr.Code != http.StatusUnauthorized && rr.Code != http.StatusBadRequest {
+		t.Fatalf("unknown client: got %d body=%q", rr.Code, rr.Body.String())
+	}
+	body := decodeJSON(t, rr)
+	if errCode, _ := body["error"].(string); errCode != "invalid_client" {
+		t.Errorf("expected invalid_client, got %q (%v)", errCode, body)
+	}
+}
+
+func TestToken_WrongClientSecret_ReturnsInvalidClient(t *testing.T) {
+	ts := buildServer(t)
+
+	form := url.Values{}
+	form.Set("grant_type", "client_credentials")
+	req := newPostForm(t, "/oauth2/token", form)
+	req.SetBasicAuth(testClientID, "wrong-secret")
+
+	rr := ts.do(req)
+	body := decodeJSON(t, rr)
+	if errCode, _ := body["error"].(string); errCode != "invalid_client" {
+		t.Errorf("expected invalid_client for bad secret, got %q (%v)", errCode, body)
+	}
+}
+
+func TestToken_UnsupportedGrantType_IsRejected(t *testing.T) {
+	ts := buildServer(t)
+
+	form := url.Values{}
+	form.Set("grant_type", "totally_made_up")
+	req := newPostForm(t, "/oauth2/token", form)
+	req.SetBasicAuth(testClientID, testClientSecret)
+
+	rr := ts.do(req)
+	if rr.Code == http.StatusOK {
+		t.Fatalf("unsupported grant type must not succeed, body=%q", rr.Body.String())
+	}
+	body := decodeJSON(t, rr)
+	if errCode, _ := body["error"].(string); errCode == "" {
+		t.Errorf("expected an OAuth2 error code, got %v", body)
+	}
+}
+
+func TestToken_AuthorizationCode_CannotBeRedeemedTwice(t *testing.T) {
+	ts := buildServer(t)
+
+	q := authzQuery(testClientID, "openid", nil)
+	code := ts.loginForCode(t, q, testUserLogin, testUserPassword)
+
+	_, rr1 := ts.exchangeCode(t, code, testClientID, testClientSecret, nil)
+	if rr1.Code != http.StatusOK {
+		t.Fatalf("first redemption should succeed, got %d body=%q", rr1.Code, rr1.Body.String())
+	}
+	// Replaying the same code must be rejected (and per RFC, fosite revokes
+	// previously issued tokens — we only assert the rejection here).
+	_, rr2 := ts.exchangeCode(t, code, testClientID, testClientSecret, nil)
+	if rr2.Code == http.StatusOK {
+		t.Fatalf("replayed authorization code must be rejected, body=%q", rr2.Body.String())
+	}
+	body := decodeJSON(t, rr2)
+	if errCode, _ := body["error"].(string); errCode == "" {
+		t.Errorf("expected an error code on code replay, got %v", body)
+	}
+}
+
+func TestToken_AuthorizationCode_WrongRedirectURIRejected(t *testing.T) {
+	ts := buildServer(t)
+
+	q := authzQuery(testClientID, "openid", nil)
+	code := ts.loginForCode(t, q, testUserLogin, testUserPassword)
+
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", code)
+	form.Set("redirect_uri", "https://evil.test/steal") // not the one used to obtain the code
+	req := newPostForm(t, "/oauth2/token", form)
+	req.SetBasicAuth(testClientID, testClientSecret)
+
+	rr := ts.do(req)
+	if rr.Code == http.StatusOK {
+		t.Fatalf("redirect_uri mismatch must be rejected, body=%q", rr.Body.String())
+	}
+	body := decodeJSON(t, rr)
+	if errCode, _ := body["error"].(string); errCode == "" {
+		t.Errorf("expected error code on redirect_uri mismatch, got %v", body)
+	}
+}
+
+// ============================================ JWT access token mode
+
+func TestToken_JwtAccessTokenMode_AccessTokenIsVerifiableJWT(t *testing.T) {
+	ts := buildServer(t, func(o *buildOpts) { o.jwtAccessToken = true })
+
+	q := authzQuery(testClientID, "openid profile", nil)
+	code := ts.loginForCode(t, q, testUserLogin, testUserPassword)
+	tokens, rr := ts.exchangeCode(t, code, testClientID, testClientSecret, nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("token exchange failed: %d %q", rr.Code, rr.Body.String())
+	}
+	accessToken := mustString(t, tokens, "access_token")
+
+	// In JWT-access-token mode the access token itself is a signed JWT.
+	tok, err := jwt.ParseSigned(accessToken)
+	if err != nil {
+		t.Fatalf("access token is not a parseable JWT: %v", err)
+	}
+	out := map[string]interface{}{}
+	if err := tok.Claims(ts.key.Public(), &out); err != nil {
+		t.Fatalf("JWT access token signature did not verify: %v", err)
+	}
+	if sub, _ := out["sub"].(string); sub != testUserLogin {
+		t.Errorf("JWT access token sub: got %q, want %q", sub, testUserLogin)
+	}
+	if iss, _ := out["iss"].(string); iss != testIssuer {
+		t.Errorf("JWT access token iss: got %q, want %q", iss, testIssuer)
+	}
+}
+
+// ----------------------------------------------------------------- helpers
+
+// parseSignedClaims verifies the JWS signature with the fixture public key and
+// returns the claims. Fails the test on any signature/parse error.
+func parseSignedClaims(t *testing.T, ts *testServer, raw string) map[string]interface{} {
+	t.Helper()
+	tok, err := jwt.ParseSigned(raw)
+	if err != nil {
+		t.Fatalf("parse signed token: %v", err)
+	}
+	claims := map[string]interface{}{}
+	if err := tok.Claims(ts.key.Public(), &claims); err != nil {
+		t.Fatalf("verify signature: %v", err)
+	}
+	return claims
+}
+
+// audienceContains handles aud being a string or a []interface{} (both legal in JWT).
+func audienceContains(aud interface{}, want string) bool {
+	switch v := aud.(type) {
+	case string:
+		return v == want
+	case []interface{}:
+		for _, e := range v {
+			if s, ok := e.(string); ok && s == want {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/cmd/oidc/oidcserver/handle_upstream_test.go
+++ b/cmd/oidc/oidcserver/handle_upstream_test.go
@@ -1,0 +1,156 @@
+/*
+Copyright (c) 2025 Kubotal.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package oidcserver
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"kubauth/cmd/oidc/upstreams"
+)
+
+// The upstream handlers run behind the login/SSO session middleware. To reach
+// branches that read the session (authQuery, state, provider), we first do a
+// GET /oauth2/login to obtain a primed session cookie, then replay it.
+
+// primedLoginCookies performs the login GET that stores authQuery in the
+// session, returning the cookies to carry into the upstream request.
+func (ts *testServer) primedLoginCookies(t *testing.T, q url.Values) []*http.Cookie {
+	t.Helper()
+	rr := ts.do(newGet(t, "/oauth2/login?"+q.Encode()))
+	cookies := readCookies(rr)
+	if len(cookies) == 0 {
+		t.Fatalf("login GET set no cookie (status %d)", rr.Code)
+	}
+	return cookies
+}
+
+func (ts *testServer) getWithCookies(t *testing.T, path string, cookies []*http.Cookie) *http.Request {
+	t.Helper()
+	req := newGet(t, path)
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+	return req
+}
+
+// ============================================ handleUpstreamGo
+
+func TestUpstreamGo_NonGet_405(t *testing.T) {
+	ts := buildServer(t)
+	rr := ts.do(newPostForm(t, "/upstream/go", url.Values{}))
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("POST /upstream/go: got %d, want 405", rr.Code)
+	}
+}
+
+func TestUpstreamGo_MissingProviderParam_400(t *testing.T) {
+	ts := buildServer(t)
+	q := authzQuery(testClientID, "openid", nil)
+	cookies := ts.primedLoginCookies(t, q)
+
+	// No upstreamProvider query param.
+	rr := ts.do(ts.getWithCookies(t, "/upstream/go", cookies))
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("missing upstreamProvider: got %d body=%q", rr.Code, rr.Body.String())
+	}
+}
+
+func TestUpstreamGo_NoAuthQueryInSession_400(t *testing.T) {
+	ts := buildServer(t)
+	// No prior login GET => no authQuery in session, but provide the param so
+	// we exercise the session guard specifically.
+	rr := ts.do(newGet(t, "/upstream/go?upstreamProvider=some"))
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("missing authQuery: got %d body=%q", rr.Code, rr.Body.String())
+	}
+}
+
+func TestUpstreamGo_UnknownUpstream_404(t *testing.T) {
+	ts := buildServer(t)
+	q := authzQuery(testClientID, "openid", nil)
+	cookies := ts.primedLoginCookies(t, q)
+
+	rr := ts.do(ts.getWithCookies(t, "/upstream/go?upstreamProvider=ghost", cookies))
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("unknown upstream: got %d body=%q", rr.Code, rr.Body.String())
+	}
+}
+
+func TestUpstreamGo_InternalUpstream_NoCodeFlow_400(t *testing.T) {
+	ts := buildServer(t)
+	// Internal upstream returns ok=false from OAuth2AuthCodeSettings.
+	ts.store.SetUpstream(testCtx(), upstreams.NewInternalUpstream("Sign in"))
+
+	q := authzQuery(testClientID, "openid", nil)
+	cookies := ts.primedLoginCookies(t, q)
+
+	rr := ts.do(ts.getWithCookies(t, "/upstream/go?upstreamProvider=internal", cookies))
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("internal upstream (no code flow): got %d body=%q", rr.Code, rr.Body.String())
+	}
+}
+
+// ============================================ handleUpstreamCallback
+
+func TestUpstreamCallback_NonGet_405(t *testing.T) {
+	ts := buildServer(t)
+	rr := ts.do(newPostForm(t, "/upstream/callback", url.Values{}))
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("POST /upstream/callback: got %d, want 405", rr.Code)
+	}
+}
+
+func TestUpstreamCallback_ProviderError_400(t *testing.T) {
+	ts := buildServer(t)
+	rr := ts.do(newGet(t, "/upstream/callback?error=access_denied&error_description=nope"))
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("upstream error param: got %d body=%q", rr.Code, rr.Body.String())
+	}
+}
+
+func TestUpstreamCallback_MissingCodeOrState_400(t *testing.T) {
+	ts := buildServer(t)
+	// code present, state missing.
+	rr := ts.do(newGet(t, "/upstream/callback?code=abc"))
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("missing state: got %d body=%q", rr.Code, rr.Body.String())
+	}
+}
+
+func TestUpstreamCallback_StateMismatch_400(t *testing.T) {
+	ts := buildServer(t)
+	// Session has no stored state, so any provided state mismatches.
+	q := authzQuery(testClientID, "openid", nil)
+	cookies := ts.primedLoginCookies(t, q)
+
+	rr := ts.do(ts.getWithCookies(t, "/upstream/callback?code=abc&state=does-not-match", cookies))
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("state mismatch: got %d body=%q", rr.Code, rr.Body.String())
+	}
+}
+
+// ============================================ handleUpstreamWelcome
+
+func TestUpstreamWelcome_NotOnDemand_404(t *testing.T) {
+	ts := buildServer(t) // default SsoMode is SsoNever
+	rr := ts.do(newGet(t, "/upstream/welcome"))
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("welcome when not onDemand: got %d, want 404 body=%q", rr.Code, rr.Body.String())
+	}
+}
+
+func TestUpstreamWelcome_OnDemand_NoPendingUser_400(t *testing.T) {
+	ts := buildServer(t, func(o *buildOpts) { o.ssoMode = SsoOnDemand })
+	// onDemand but no pending upstream user in session.
+	rr := ts.do(newGet(t, "/upstream/welcome"))
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("welcome with no pending user: got %d, want 400 body=%q", rr.Code, rr.Body.String())
+	}
+}

--- a/cmd/oidc/oidcserver/handle_userinfo_test.go
+++ b/cmd/oidc/oidcserver/handle_userinfo_test.go
@@ -1,0 +1,114 @@
+/*
+Copyright (c) 2025 Kubotal.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package oidcserver
+
+import (
+	"net/http"
+	"testing"
+)
+
+// accessTokenForUser runs the full code flow and returns an opaque/JWT access
+// token plus the token-response map, for use by userinfo / introspection tests.
+func (ts *testServer) accessTokenForUser(t *testing.T, scope string) string {
+	t.Helper()
+	q := authzQuery(testClientID, scope, nil)
+	code := ts.loginForCode(t, q, testUserLogin, testUserPassword)
+	tokens, rr := ts.exchangeCode(t, code, testClientID, testClientSecret, nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("token exchange failed: %d %q", rr.Code, rr.Body.String())
+	}
+	return mustString(t, tokens, "access_token")
+}
+
+// ============================================ /userinfo
+
+func TestUserInfo_ValidBearer_ReturnsSubAndMappedClaims(t *testing.T) {
+	ts := buildServer(t)
+	accessToken := ts.accessTokenForUser(t, "openid profile email groups")
+
+	req := newGet(t, "/userinfo")
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	rr := ts.do(req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("userinfo: got %d body=%q", rr.Code, rr.Body.String())
+	}
+	if ct := rr.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("content-type: got %q", ct)
+	}
+	claims := decodeJSON(t, rr)
+	if sub, _ := claims["sub"].(string); sub != testUserLogin {
+		t.Errorf("sub: got %q, want %q", sub, testUserLogin)
+	}
+	if email, _ := claims["email"].(string); email != "alice@test" {
+		t.Errorf("email claim: got %q, want alice@test", email)
+	}
+	if name, _ := claims["name"].(string); name != "Alice Example" {
+		t.Errorf("name claim: got %q", name)
+	}
+	// azp is explicitly stripped from the userinfo response by the handler.
+	if _, present := claims["azp"]; present {
+		t.Error("azp must not be exposed via /userinfo")
+	}
+}
+
+func TestUserInfo_MissingAuthorizationHeader_Returns401(t *testing.T) {
+	ts := buildServer(t)
+
+	rr := ts.do(newGet(t, "/userinfo"))
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("no auth header: got %d, want 401", rr.Code)
+	}
+	if wa := rr.Header().Get("WWW-Authenticate"); wa == "" {
+		t.Error("a 401 from userinfo must carry a WWW-Authenticate challenge")
+	}
+}
+
+func TestUserInfo_NonBearerScheme_Returns401(t *testing.T) {
+	ts := buildServer(t)
+
+	req := newGet(t, "/userinfo")
+	req.Header.Set("Authorization", "Basic dXNlcjpwYXNz")
+	rr := ts.do(req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("non-bearer scheme: got %d, want 401 body=%q", rr.Code, rr.Body.String())
+	}
+}
+
+func TestUserInfo_GarbageToken_Returns401(t *testing.T) {
+	ts := buildServer(t)
+
+	req := newGet(t, "/userinfo")
+	req.Header.Set("Authorization", "Bearer not-a-real-token")
+	rr := ts.do(req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("garbage token: got %d, want 401 body=%q", rr.Code, rr.Body.String())
+	}
+	if wa := rr.Header().Get("WWW-Authenticate"); wa == "" {
+		t.Error("invalid token must yield a WWW-Authenticate challenge")
+	}
+}
+
+func TestUserInfo_JwtAccessTokenMode_StillResolvesClaims(t *testing.T) {
+	ts := buildServer(t, func(o *buildOpts) { o.jwtAccessToken = true })
+	accessToken := ts.accessTokenForUser(t, "openid email")
+
+	req := newGet(t, "/userinfo")
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	rr := ts.do(req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("userinfo (jwt mode): got %d body=%q", rr.Code, rr.Body.String())
+	}
+	claims := decodeJSON(t, rr)
+	if sub, _ := claims["sub"].(string); sub != testUserLogin {
+		t.Errorf("sub: got %q, want %q", sub, testUserLogin)
+	}
+}

--- a/cmd/oidc/oidcserver/setup_test.go
+++ b/cmd/oidc/oidcserver/setup_test.go
@@ -1,0 +1,209 @@
+/*
+Copyright (c) 2025 Kubotal.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package oidcserver
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"kubauth/cmd/oidc/oidcstorage"
+
+	scsV2 "github.com/alexedwards/scs/v2"
+	scsmem "github.com/alexedwards/scs/v2/memstore"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+)
+
+// bareServer builds an unconfigured OIDCServer wired with the given kube client.
+// Used to drive Setup()/ensureJwtSigningKey directly.
+func bareServer(t *testing.T, kube client.Client, secretName, secretNS string) *OIDCServer {
+	t.Helper()
+	loginTmpl, indexTmpl, welcomeTmpl := testTemplates()
+	sso := scsV2.New()
+	sso.Store = scsmem.New()
+	login := scsV2.New()
+	login.Store = scsmem.New()
+	return &OIDCServer{
+		Issuer:                  testIssuer,
+		Storage:                 oidcstorage.NewMemoryStore(defaultAuth()),
+		Authenticator:           defaultAuth(),
+		Resources:               t.TempDir(),
+		LoginTemplate:           loginTmpl,
+		IndexTemplate:           indexTmpl,
+		UpstreamWelcomeTemplate: welcomeTmpl,
+		SsoSessionManager:       sso,
+		LoginSessionManager:     login,
+		KubeClient:              kube,
+		EventRecorder:           record.NewFakeRecorder(16),
+		JWTSigningKeySecretName: secretName,
+		JWTSigningKeySecretNS:   secretNS,
+		AccessTokenLifespan:     time.Hour,
+		RefreshTokenLifespan:    time.Hour,
+	}
+}
+
+// ============================================ Setup wires the storage
+
+func TestSetup_PropagatesConfigToStorage(t *testing.T) {
+	ts := buildServer(t, func(o *buildOpts) { o.allowPasswordGrant = true })
+	if ts.store.Issuer != testIssuer {
+		t.Errorf("Setup must set storage.Issuer: got %q", ts.store.Issuer)
+	}
+	if ts.store.KeyID != ts.kid {
+		t.Errorf("Setup must set storage.KeyID: got %q, want %q", ts.store.KeyID, ts.kid)
+	}
+	if !ts.store.AllowPasswordGrant {
+		t.Error("Setup must propagate AllowPasswordGrant to storage")
+	}
+	if ts.store.Authenticator == nil {
+		t.Error("Setup must wire the authenticator into storage")
+	}
+}
+
+// ============================================ ensureJwtSigningKey: generate
+
+func TestEnsureJwtSigningKey_GeneratesAndPersistsWhenAbsent(t *testing.T) {
+	const name, ns = "gen-key", "kubauth-system"
+	kube := fake.NewClientBuilder().WithScheme(newScheme(t)).Build() // no secret seeded
+
+	s := bareServer(t, kube, name, ns)
+	mux := http.NewServeMux()
+	if err := s.Setup(testCtx(), mux); err != nil {
+		t.Fatalf("Setup: %v", err)
+	}
+
+	// A key + kid must now exist in-memory.
+	if s.privateKey == nil || s.keyID == "" {
+		t.Fatalf("expected a generated key and kid, got key=%v kid=%q", s.privateKey, s.keyID)
+	}
+	// And it must have been persisted to a Secret for restart stability.
+	sec := &corev1.Secret{}
+	if err := kube.Get(testCtx(), client.ObjectKey{Name: name, Namespace: ns}, sec); err != nil {
+		t.Fatalf("generated key should be persisted as a Secret: %v", err)
+	}
+	if len(sec.Data["key.pem"]) == 0 || string(sec.Data["kid"]) != s.keyID {
+		t.Errorf("persisted secret malformed: kidData=%q serverKid=%q", sec.Data["kid"], s.keyID)
+	}
+}
+
+// ============================================ ensureJwtSigningKey: load existing
+
+func TestEnsureJwtSigningKey_LoadsExistingKid(t *testing.T) {
+	const name, ns = "load-key", "kubauth-system"
+	sec, _, kid := preGeneratedKeySecret(t, name, ns)
+	kube := fake.NewClientBuilder().WithScheme(newScheme(t)).WithObjects(sec).Build()
+
+	s := bareServer(t, kube, name, ns)
+	if err := s.Setup(testCtx(), http.NewServeMux()); err != nil {
+		t.Fatalf("Setup: %v", err)
+	}
+	if s.keyID != kid {
+		t.Errorf("must load existing kid: got %q, want %q", s.keyID, kid)
+	}
+}
+
+// ============================================ ensureJwtSigningKey: malformed
+
+func TestEnsureJwtSigningKey_MissingDataKeys_Errors(t *testing.T) {
+	const name, ns = "bad-key", "kubauth-system"
+	sec := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Type:       corev1.SecretTypeOpaque,
+		Data:       map[string][]byte{"kid": []byte("x")}, // missing key.pem
+	}
+	kube := fake.NewClientBuilder().WithScheme(newScheme(t)).WithObjects(sec).Build()
+
+	s := bareServer(t, kube, name, ns)
+	err := s.Setup(testCtx(), http.NewServeMux())
+	if err == nil {
+		t.Fatal("Setup must fail when the key secret is missing required data keys")
+	}
+}
+
+func TestEnsureJwtSigningKey_UndecodablePEM_Errors(t *testing.T) {
+	const name, ns = "bad-pem", "kubauth-system"
+	sec := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Type:       corev1.SecretTypeOpaque,
+		Data:       map[string][]byte{"key.pem": []byte("not a pem block"), "kid": []byte("x")},
+	}
+	kube := fake.NewClientBuilder().WithScheme(newScheme(t)).WithObjects(sec).Build()
+
+	s := bareServer(t, kube, name, ns)
+	if err := s.Setup(testCtx(), http.NewServeMux()); err == nil {
+		t.Fatal("Setup must fail on an undecodable PEM in the key secret")
+	}
+}
+
+// ============================================ ensureJwtSigningKey: Get failure
+
+// Inject a non-NotFound Get error via interceptor so ensureJwtSigningKey takes
+// the "failed to load" branch (not the generate branch).
+func TestEnsureJwtSigningKey_GetError_Propagates(t *testing.T) {
+	const name, ns = "err-key", "kubauth-system"
+	boom := errors.New("apiserver unavailable")
+	kube := fake.NewClientBuilder().
+		WithScheme(newScheme(t)).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(_ context.Context, _ client.WithWatch, key client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+				if key.Name == name {
+					return boom
+				}
+				return nil
+			},
+		}).
+		Build()
+
+	s := bareServer(t, kube, name, ns)
+	err := s.Setup(testCtx(), http.NewServeMux())
+	if err == nil {
+		t.Fatal("Setup must fail when the key Secret Get returns a non-NotFound error")
+	}
+}
+
+// ============================================ ensureJwtSigningKey: Create failure
+
+// When the secret is absent (NotFound) but Create fails, generation must error.
+func TestEnsureJwtSigningKey_CreateError_Propagates(t *testing.T) {
+	const name, ns = "create-fail", "kubauth-system"
+	boom := errors.New("quota exceeded")
+	kube := fake.NewClientBuilder().
+		WithScheme(newScheme(t)).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(_ context.Context, _ client.WithWatch, obj client.Object, _ ...client.CreateOption) error {
+				if _, ok := obj.(*corev1.Secret); ok {
+					return boom
+				}
+				return nil
+			},
+		}).
+		Build()
+
+	s := bareServer(t, kube, name, ns)
+	if err := s.Setup(testCtx(), http.NewServeMux()); err == nil {
+		t.Fatal("Setup must fail when persisting a newly generated key fails")
+	}
+}
+
+// ============================================ runtime scheme sanity
+
+// Guards against a future fixture change that forgets to register core/v1,
+// which would make every Secret op silently fail with a scheme error.
+func TestScheme_RegistersCoreAndCRD(t *testing.T) {
+	s := newScheme(t)
+	if !s.Recognizes(corev1.SchemeGroupVersion.WithKind("Secret")) {
+		t.Error("scheme must recognise core/v1 Secret")
+	}
+}

--- a/cmd/oidc/oidcserver/upstream_claims_map_test.go
+++ b/cmd/oidc/oidcserver/upstream_claims_map_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright (c) 2025 Kubotal.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package oidcserver
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMapUpstreamClaimsToUser_NilClaims_Errors(t *testing.T) {
+	u, err := mapUpstreamClaimsToUser(nil)
+	if err == nil {
+		t.Fatal("nil claims must return an error")
+	}
+	if u != nil {
+		t.Errorf("user must be nil on error, got %+v", u)
+	}
+}
+
+func TestMapUpstreamClaimsToUser_MissingSub_Errors(t *testing.T) {
+	u, err := mapUpstreamClaimsToUser(map[string]interface{}{"name": "Bob"})
+	if err == nil {
+		t.Fatal("claims without sub must return an error")
+	}
+	if u != nil {
+		t.Errorf("user must be nil when sub is missing, got %+v", u)
+	}
+}
+
+func TestMapUpstreamClaimsToUser_EmptySub_Errors(t *testing.T) {
+	// sub present but empty is treated as missing.
+	_, err := mapUpstreamClaimsToUser(map[string]interface{}{"sub": ""})
+	if err == nil {
+		t.Fatal("empty sub must return an error")
+	}
+}
+
+func TestMapUpstreamClaimsToUser_NonStringSub_Errors(t *testing.T) {
+	// A non-string sub fails the `claims["sub"].(string)` assertion -> "".
+	_, err := mapUpstreamClaimsToUser(map[string]interface{}{"sub": 12345})
+	if err == nil {
+		t.Fatal("non-string sub must return an error")
+	}
+}
+
+func TestMapUpstreamClaimsToUser_LoginIsSubAndClaimsPreserved(t *testing.T) {
+	claims := map[string]interface{}{
+		"sub":    "user-42",
+		"name":   "Carol Coder",
+		"email":  "carol@test",
+		"groups": []string{"a", "b"},
+	}
+	u, err := mapUpstreamClaimsToUser(claims)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if u.Login != "user-42" {
+		t.Errorf("login must equal sub: got %q", u.Login)
+	}
+	if u.FullName != "Carol Coder" {
+		t.Errorf("fullName must come from the name claim: got %q", u.FullName)
+	}
+	// The original claim map is carried through verbatim (same contents).
+	if !reflect.DeepEqual(u.Claims, claims) {
+		t.Errorf("claims not preserved: got %v, want %v", u.Claims, claims)
+	}
+}
+
+func TestMapUpstreamClaimsToUser_MissingName_EmptyFullName(t *testing.T) {
+	u, err := mapUpstreamClaimsToUser(map[string]interface{}{"sub": "user-1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if u.FullName != "" {
+		t.Errorf("missing name claim must yield empty FullName, got %q", u.FullName)
+	}
+}
+
+func TestMapUpstreamClaimsToUser_NonStringName_EmptyFullName(t *testing.T) {
+	u, err := mapUpstreamClaimsToUser(map[string]interface{}{"sub": "user-1", "name": 99})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if u.FullName != "" {
+		t.Errorf("non-string name must yield empty FullName, got %q", u.FullName)
+	}
+}

--- a/cmd/oidc/oidcstorage/kubauthclient_test.go
+++ b/cmd/oidc/oidcstorage/kubauthclient_test.go
@@ -1,0 +1,255 @@
+/*
+Copyright (c) 2025 Kubotal.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package oidcstorage
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"kubauth/api/kubauth/v1alpha1"
+
+	"github.com/ory/hydra/v2/fosite"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// helpers ----------------------------------------------------------------
+
+func boolPtr(b bool) *bool { return &b }
+
+func sampleOidcClient() *v1alpha1.OidcClient {
+	return &v1alpha1.OidcClient{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "kubauth-system",
+			Name:      "smoke-client",
+		},
+		Spec: v1alpha1.OidcClientSpec{
+			RedirectURIs:        []string{"https://app/callback", "https://app/cb"},
+			GrantTypes:          []string{"authorization_code", "refresh_token"},
+			ResponseTypes:       []string{"code"},
+			Scopes:              []string{"openid", "profile", "email"},
+			Audiences:           []string{"smoke-client", "another-aud"},
+			Public:              false,
+			Description:         "test client",
+			EntryURL:            "https://app/",
+			PostLogoutURL:       "https://app/logged-out",
+			DisplayName:         "Smoke Client",
+			Style:               "default",
+			UpstreamProviders:   []string{"up-public"},
+			AccessTokenLifespan: metav1.Duration{Duration: 30 * time.Minute},
+			IDTokenLifespan:     metav1.Duration{Duration: 5 * time.Minute},
+			// RefreshTokenLifespan left zero — fallback applies.
+		},
+	}
+}
+
+// Constructor + identity -------------------------------------------------
+
+func TestNewKubauthClient_PopulatesIDsAndK8sId(t *testing.T) {
+	cli := sampleOidcClient()
+	hashes := [][]byte{[]byte("hash-a"), []byte("hash-b")}
+	c := NewKubauthClient(cli, "smoke-client", hashes)
+	if c.GetID() != "smoke-client" {
+		t.Errorf("GetID: got %q", c.GetID())
+	}
+	// k8sId is `<namespace>:<name>` — used to detect cross-namespace
+	// duplicate registrations.
+	if c.GetK8sId() != "kubauth-system:smoke-client" {
+		t.Errorf("GetK8sId: got %q", c.GetK8sId())
+	}
+}
+
+func TestGetK8sObject_ReturnsSameInstance(t *testing.T) {
+	cli := sampleOidcClient()
+	c := NewKubauthClient(cli, "id", nil)
+	if c.GetK8sObject() != cli {
+		t.Error("GetK8sObject must return the original CR pointer (no copy)")
+	}
+}
+
+// Hashed secrets ---------------------------------------------------------
+
+func TestSecrets_NilSlicesGiveNilAndZero(t *testing.T) {
+	c := NewKubauthClient(sampleOidcClient(), "id", nil)
+	if got := c.GetHashedSecret(); got != nil {
+		t.Errorf("nil secrets: GetHashedSecret should be nil, got %v", got)
+	}
+	if got := c.GetRotatedHashes(); got != nil {
+		t.Errorf("nil secrets: GetRotatedHashes should be nil, got %v", got)
+	}
+	if c.GetSecretCount() != 0 {
+		t.Errorf("nil secrets: count should be 0, got %d", c.GetSecretCount())
+	}
+}
+
+func TestSecrets_FirstIsActiveRestAreRotated(t *testing.T) {
+	c := NewKubauthClient(sampleOidcClient(), "id", [][]byte{
+		[]byte("active"), []byte("rot1"), []byte("rot2"),
+	})
+	if string(c.GetHashedSecret()) != "active" {
+		t.Errorf("active secret should be the first, got %q", c.GetHashedSecret())
+	}
+	rot := c.GetRotatedHashes()
+	if len(rot) != 2 || string(rot[0]) != "rot1" || string(rot[1]) != "rot2" {
+		t.Errorf("rotated secrets wrong: %v", rot)
+	}
+	if c.GetSecretCount() != 3 {
+		t.Errorf("count: got %d", c.GetSecretCount())
+	}
+}
+
+func TestSecrets_OnlyOneSecret_NoRotated(t *testing.T) {
+	c := NewKubauthClient(sampleOidcClient(), "id", [][]byte{[]byte("only")})
+	if rot := c.GetRotatedHashes(); rot != nil && len(rot) != 0 {
+		t.Errorf("single-secret client: rotated should be empty, got %v", rot)
+	}
+}
+
+// Spec accessors (mirrored fields) ---------------------------------------
+
+func TestSpecAccessors_ReturnSpecFields(t *testing.T) {
+	cli := sampleOidcClient()
+	c := NewKubauthClient(cli, "smoke-client", nil)
+	cases := []struct {
+		name string
+		got  any
+		want any
+	}{
+		{"RedirectURIs", c.GetRedirectURIs(), []string{"https://app/callback", "https://app/cb"}},
+		{"GrantTypes", []string(c.GetGrantTypes()), []string{"authorization_code", "refresh_token"}},
+		{"ResponseTypes", []string(c.GetResponseTypes()), []string{"code"}},
+		{"Scopes", []string(c.GetScopes()), []string{"openid", "profile", "email"}},
+		{"IsPublic", c.IsPublic(), false},
+		{"Description", c.GetDescription(), "test client"},
+		{"EntryURL", c.GetEntryURL(), "https://app/"},
+		{"PostLogoutURL", c.GetPostLogoutURL(), "https://app/logged-out"},
+		{"DisplayName", c.GetDisplayName(), "Smoke Client"},
+		{"Style", c.GetStyle(), "default"},
+		{"UpstreamProviders", c.GetUpstreamProviders(), []string{"up-public"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if !reflect.DeepEqual(tc.got, tc.want) {
+				t.Errorf("got %v, want %v", tc.got, tc.want)
+			}
+		})
+	}
+}
+
+// IsForceOpenIdScope (nil ptr handling) ----------------------------------
+
+func TestIsForceOpenIdScope_NilDefaultsFalse(t *testing.T) {
+	cli := sampleOidcClient() // ForceOpenIdScope unset
+	c := NewKubauthClient(cli, "id", nil)
+	if c.IsForceOpenIdScope() {
+		t.Error("nil pointer should default to false")
+	}
+}
+
+func TestIsForceOpenIdScope_TrueWhenSet(t *testing.T) {
+	cli := sampleOidcClient()
+	cli.Spec.ForceOpenIdScope = boolPtr(true)
+	c := NewKubauthClient(cli, "id", nil)
+	if !c.IsForceOpenIdScope() {
+		t.Error("expected true")
+	}
+}
+
+func TestIsForceOpenIdScope_FalseWhenSet(t *testing.T) {
+	cli := sampleOidcClient()
+	cli.Spec.ForceOpenIdScope = boolPtr(false)
+	c := NewKubauthClient(cli, "id", nil)
+	if c.IsForceOpenIdScope() {
+		t.Error("expected false")
+	}
+}
+
+// GetAudience (auto-include client_id) -----------------------------------
+
+func TestGetAudience_IncludesClientIdWhenNotPresent(t *testing.T) {
+	// HandleAudience() in fosite defaults to granting client_id when no
+	// audience is explicitly requested. Kubauth allows it implicitly.
+	cli := sampleOidcClient()
+	cli.Spec.Audiences = []string{"only-aud"} // no smoke-client
+	c := NewKubauthClient(cli, "smoke-client", nil)
+	got := c.GetAudience()
+	found := false
+	for _, a := range got {
+		if a == "smoke-client" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("client id should be appended to audiences, got %v", got)
+	}
+}
+
+func TestGetAudience_ReturnsAsIsWhenClientIdAlreadyPresent(t *testing.T) {
+	cli := sampleOidcClient() // contains "smoke-client" in audiences
+	c := NewKubauthClient(cli, "smoke-client", nil)
+	got := c.GetAudience()
+	count := 0
+	for _, a := range got {
+		if a == "smoke-client" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("client id should appear exactly once when already in spec, got %d", count)
+	}
+}
+
+// GetEffectiveLifespan ---------------------------------------------------
+
+func TestGetEffectiveLifespan_AccessTokenUsesSpecValue(t *testing.T) {
+	cli := sampleOidcClient() // AccessTokenLifespan = 30m
+	c := NewKubauthClient(cli, "id", nil).(fosite.ClientWithCustomTokenLifespans)
+	got := c.GetEffectiveLifespan(fosite.GrantTypeAuthorizationCode, fosite.AccessToken, time.Hour)
+	if got != 30*time.Minute {
+		t.Errorf("expected 30m, got %v", got)
+	}
+}
+
+func TestGetEffectiveLifespan_IDTokenUsesSpecValue(t *testing.T) {
+	cli := sampleOidcClient() // IDTokenLifespan = 5m
+	c := NewKubauthClient(cli, "id", nil).(fosite.ClientWithCustomTokenLifespans)
+	got := c.GetEffectiveLifespan(fosite.GrantTypeAuthorizationCode, fosite.IDToken, time.Hour)
+	if got != 5*time.Minute {
+		t.Errorf("expected 5m, got %v", got)
+	}
+}
+
+func TestGetEffectiveLifespan_RefreshTokenUnsetUsesFallback(t *testing.T) {
+	cli := sampleOidcClient() // RefreshTokenLifespan unset (zero)
+	c := NewKubauthClient(cli, "id", nil).(fosite.ClientWithCustomTokenLifespans)
+	fallback := 7 * 24 * time.Hour
+	got := c.GetEffectiveLifespan(fosite.GrantTypeAuthorizationCode, fosite.RefreshToken, fallback)
+	if got != fallback {
+		t.Errorf("expected fallback %v, got %v", fallback, got)
+	}
+}
+
+func TestGetEffectiveLifespan_AccessTokenUnsetUsesFallback(t *testing.T) {
+	cli := sampleOidcClient()
+	cli.Spec.AccessTokenLifespan = metav1.Duration{} // zero
+	c := NewKubauthClient(cli, "id", nil).(fosite.ClientWithCustomTokenLifespans)
+	fallback := 90 * time.Minute
+	got := c.GetEffectiveLifespan(fosite.GrantTypeAuthorizationCode, fosite.AccessToken, fallback)
+	if got != fallback {
+		t.Errorf("expected fallback %v, got %v", fallback, got)
+	}
+}
+
+func TestGetEffectiveLifespan_UnknownTokenTypeUsesFallback(t *testing.T) {
+	c := NewKubauthClient(sampleOidcClient(), "id", nil).(fosite.ClientWithCustomTokenLifespans)
+	fallback := 13 * time.Second
+	got := c.GetEffectiveLifespan(fosite.GrantTypeAuthorizationCode, fosite.TokenType("unknown"), fallback)
+	if got != fallback {
+		t.Errorf("expected fallback for unknown token type, got %v", fallback)
+	}
+}

--- a/cmd/oidc/oidcstorage/kubauthclient_test.go
+++ b/cmd/oidc/oidcstorage/kubauthclient_test.go
@@ -105,7 +105,7 @@ func TestSecrets_FirstIsActiveRestAreRotated(t *testing.T) {
 
 func TestSecrets_OnlyOneSecret_NoRotated(t *testing.T) {
 	c := NewKubauthClient(sampleOidcClient(), "id", [][]byte{[]byte("only")})
-	if rot := c.GetRotatedHashes(); rot != nil && len(rot) != 0 {
+	if rot := c.GetRotatedHashes(); len(rot) != 0 {
 		t.Errorf("single-secret client: rotated should be empty, got %v", rot)
 	}
 }

--- a/cmd/oidc/oidcstorage/memory_test.go
+++ b/cmd/oidc/oidcstorage/memory_test.go
@@ -1,0 +1,916 @@
+/*
+Copyright (c) 2025 Kubotal.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package oidcstorage
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"kubauth/api/kubauth/v1alpha1"
+	"kubauth/cmd/oidc/authenticator"
+	"kubauth/cmd/oidc/upstreams"
+	"kubauth/internal/proto"
+
+	"github.com/go-jose/go-jose/v3"
+	"github.com/go-logr/logr"
+	"github.com/ory/hydra/v2/fosite"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// testCtx returns a context carrying a discard slog logger. Several MemoryStore
+// methods call logr.FromContextAsSlogLogger(ctx) and panic on a bare context.
+func testCtx() context.Context {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	return logr.NewContextWithSlogLogger(context.Background(), logger)
+}
+
+// newJWK builds a minimal RSA public JWK tagged with keyID, used to seed the
+// store's issuer public-key tables.
+func newJWK(t *testing.T, keyID string) *jose.JSONWebKey {
+	t.Helper()
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa.GenerateKey: %v", err)
+	}
+	return &jose.JSONWebKey{
+		Key:       priv.Public(),
+		KeyID:     keyID,
+		Algorithm: "RS256",
+		Use:       "sig",
+	}
+}
+
+// ---------------------------------------------------------------- test doubles
+
+// fakeAuthenticator is a configurable authenticator.OidcAuthenticator used to
+// drive MemoryStore.Authenticate / AuthenticateUserWithClaims down both the
+// success and error branches.
+type fakeAuthenticator struct {
+	user *authenticator.OidcUser
+	err  error
+}
+
+func (f *fakeAuthenticator) Identify(_ context.Context, _ string, _ string) (*authenticator.OidcUser, proto.Status, error) {
+	return f.user, proto.PasswordChecked, f.err
+}
+
+func (f *fakeAuthenticator) Authenticate(_ context.Context, _ string, _ string) (*authenticator.OidcUser, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.user, nil
+}
+
+var _ authenticator.OidcAuthenticator = &fakeAuthenticator{}
+
+// newStore builds a MemoryStore with a fake authenticator that returns user.
+func newStore(t *testing.T, user *authenticator.OidcUser, authErr error) *MemoryStore {
+	t.Helper()
+	return NewMemoryStore(&fakeAuthenticator{user: user, err: authErr})
+}
+
+// req builds a minimal fosite.Requester with a stable request ID, the value the
+// token storage methods index by (GetID()).
+func req(id string) fosite.Requester {
+	r := fosite.NewRequest()
+	r.SetID(id)
+	return r
+}
+
+// internalUpstream returns a real, network-free upstreams.Upstream of the
+// Internal type whose GetName() == name. NewUpstream short-circuits for the
+// Internal type and never touches the network.
+func internalUpstream(t *testing.T, name string) upstreams.Upstream {
+	t.Helper()
+	u, err := upstreams.NewUpstream(testCtx(), &v1alpha1.UpstreamProvider{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: v1alpha1.UpstreamProviderSpec{
+			Type:        v1alpha1.UpstreamProviderTypeInternal,
+			DisplayName: name + " display",
+		},
+	}, "", nil)
+	if err != nil {
+		t.Fatalf("internalUpstream(%q): unexpected error %v", name, err)
+	}
+	return u
+}
+
+// ---------------------------------------------------------------- constructor
+
+func TestNewMemoryStore_InitializesMapsAndAuthenticator(t *testing.T) {
+	a := &fakeAuthenticator{}
+	s := NewMemoryStore(a)
+	if s.Clients == nil || s.AuthorizeCodes == nil || s.IDSessions == nil ||
+		s.AccessTokens == nil || s.RefreshTokens == nil || s.PKCES == nil ||
+		s.AccessTokenRequestIDs == nil || s.RefreshTokenRequestIDs == nil ||
+		s.BlacklistedJTIs == nil || s.IssuerPublicKeys == nil ||
+		s.PARSessions == nil || s.Upstreams == nil {
+		t.Fatal("NewMemoryStore left one or more maps nil")
+	}
+	if s.Authenticator != a {
+		t.Error("authenticator not wired into the store")
+	}
+}
+
+// ---------------------------------------------------------------- OIDC session
+
+func TestOpenIDConnectSession_RoundTrip(t *testing.T) {
+	ctx := testCtx()
+	s := newStore(t, nil, nil)
+	want := req("oidc-1")
+
+	if err := s.CreateOpenIDConnectSession(ctx, "code-1", want); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	got, err := s.GetOpenIDConnectSession(ctx, "code-1", req("oidc-1"))
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.GetID() != "oidc-1" {
+		t.Errorf("get returned wrong requester id %q", got.GetID())
+	}
+
+	if err := s.DeleteOpenIDConnectSession(ctx, "code-1"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if _, err := s.GetOpenIDConnectSession(ctx, "code-1", req("oidc-1")); !errors.Is(err, fosite.ErrNotFound) {
+		t.Errorf("after delete: want ErrNotFound, got %v", err)
+	}
+}
+
+func TestGetOpenIDConnectSession_NotFound(t *testing.T) {
+	s := newStore(t, nil, nil)
+	got, err := s.GetOpenIDConnectSession(testCtx(), "missing", req("x"))
+	if !errors.Is(err, fosite.ErrNotFound) {
+		t.Errorf("want ErrNotFound, got %v", err)
+	}
+	if got != nil {
+		t.Errorf("want nil requester on miss, got %v", got)
+	}
+}
+
+func TestDeleteOpenIDConnectSession_MissingIsNoop(t *testing.T) {
+	s := newStore(t, nil, nil)
+	if err := s.DeleteOpenIDConnectSession(testCtx(), "never-created"); err != nil {
+		t.Errorf("deleting an absent session should be a no-op, got %v", err)
+	}
+}
+
+// ---------------------------------------------------------------- authorize code
+
+func TestAuthorizeCodeSession_RoundTrip(t *testing.T) {
+	ctx := testCtx()
+	s := newStore(t, nil, nil)
+
+	if err := s.CreateAuthorizeCodeSession(ctx, "ac-1", req("ac-req-1")); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	got, err := s.GetAuthorizeCodeSession(ctx, "ac-1", nil)
+	if err != nil {
+		t.Fatalf("get active: %v", err)
+	}
+	if got.GetID() != "ac-req-1" {
+		t.Errorf("wrong requester id %q", got.GetID())
+	}
+}
+
+func TestGetAuthorizeCodeSession_NotFound(t *testing.T) {
+	s := newStore(t, nil, nil)
+	if _, err := s.GetAuthorizeCodeSession(testCtx(), "nope", nil); !errors.Is(err, fosite.ErrNotFound) {
+		t.Errorf("want ErrNotFound, got %v", err)
+	}
+}
+
+func TestInvalidateAuthorizeCodeSession_MarksInactiveAndStillReturnsRequester(t *testing.T) {
+	ctx := testCtx()
+	s := newStore(t, nil, nil)
+	if err := s.CreateAuthorizeCodeSession(ctx, "ac-2", req("ac-req-2")); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if err := s.InvalidateAuthorizeCodeSession(ctx, "ac-2"); err != nil {
+		t.Fatalf("invalidate: %v", err)
+	}
+	// After invalidation Get must surface ErrInvalidatedAuthorizeCode but still
+	// hand back the (now inactive) requester so the caller can revoke tokens.
+	got, err := s.GetAuthorizeCodeSession(ctx, "ac-2", nil)
+	if !errors.Is(err, fosite.ErrInvalidatedAuthorizeCode) {
+		t.Errorf("want ErrInvalidatedAuthorizeCode, got %v", err)
+	}
+	if got == nil {
+		t.Error("invalidated code should still return a (non-nil) requester")
+	}
+}
+
+func TestInvalidateAuthorizeCodeSession_NotFound(t *testing.T) {
+	s := newStore(t, nil, nil)
+	if err := s.InvalidateAuthorizeCodeSession(testCtx(), "ghost"); !errors.Is(err, fosite.ErrNotFound) {
+		t.Errorf("want ErrNotFound, got %v", err)
+	}
+}
+
+// ---------------------------------------------------------------- PKCE
+
+func TestPKCERequestSession_RoundTrip(t *testing.T) {
+	ctx := testCtx()
+	s := newStore(t, nil, nil)
+
+	if err := s.CreatePKCERequestSession(ctx, "pkce-1", req("pkce-req-1")); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	got, err := s.GetPKCERequestSession(ctx, "pkce-1", nil)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.GetID() != "pkce-req-1" {
+		t.Errorf("wrong requester id %q", got.GetID())
+	}
+
+	if err := s.DeletePKCERequestSession(ctx, "pkce-1"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if _, err := s.GetPKCERequestSession(ctx, "pkce-1", nil); !errors.Is(err, fosite.ErrNotFound) {
+		t.Errorf("after delete: want ErrNotFound, got %v", err)
+	}
+}
+
+func TestGetPKCERequestSession_NotFound(t *testing.T) {
+	s := newStore(t, nil, nil)
+	if _, err := s.GetPKCERequestSession(testCtx(), "absent", nil); !errors.Is(err, fosite.ErrNotFound) {
+		t.Errorf("want ErrNotFound, got %v", err)
+	}
+}
+
+func TestDeletePKCERequestSession_MissingIsNoop(t *testing.T) {
+	s := newStore(t, nil, nil)
+	if err := s.DeletePKCERequestSession(testCtx(), "absent"); err != nil {
+		t.Errorf("deleting absent pkce should be no-op, got %v", err)
+	}
+}
+
+// ---------------------------------------------------------------- access token
+
+func TestAccessTokenSession_RoundTripAndRequestIDIndex(t *testing.T) {
+	ctx := testCtx()
+	s := newStore(t, nil, nil)
+
+	if err := s.CreateAccessTokenSession(ctx, "sig-at-1", req("at-req-1")); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	got, err := s.GetAccessTokenSession(ctx, "sig-at-1", nil)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.GetID() != "at-req-1" {
+		t.Errorf("wrong requester id %q", got.GetID())
+	}
+	// The request-ID -> signature side index must be populated for revocation.
+	if sig := s.AccessTokenRequestIDs["at-req-1"]; sig != "sig-at-1" {
+		t.Errorf("request-id index: got %q, want %q", sig, "sig-at-1")
+	}
+
+	if err := s.DeleteAccessTokenSession(ctx, "sig-at-1"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if _, err := s.GetAccessTokenSession(ctx, "sig-at-1", nil); !errors.Is(err, fosite.ErrNotFound) {
+		t.Errorf("after delete: want ErrNotFound, got %v", err)
+	}
+}
+
+func TestGetAccessTokenSession_NotFound(t *testing.T) {
+	s := newStore(t, nil, nil)
+	if _, err := s.GetAccessTokenSession(testCtx(), "missing", nil); !errors.Is(err, fosite.ErrNotFound) {
+		t.Errorf("want ErrNotFound, got %v", err)
+	}
+}
+
+func TestRevokeAccessToken_DeletesByRequestID(t *testing.T) {
+	ctx := testCtx()
+	s := newStore(t, nil, nil)
+	if err := s.CreateAccessTokenSession(ctx, "sig-at-2", req("at-req-2")); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if err := s.RevokeAccessToken(ctx, "at-req-2"); err != nil {
+		t.Fatalf("revoke: %v", err)
+	}
+	if _, err := s.GetAccessTokenSession(ctx, "sig-at-2", nil); !errors.Is(err, fosite.ErrNotFound) {
+		t.Errorf("revoked token should be gone, got %v", err)
+	}
+}
+
+func TestRevokeAccessToken_UnknownRequestIDIsNoop(t *testing.T) {
+	// Unknown request id is not an error: there is simply nothing to revoke.
+	s := newStore(t, nil, nil)
+	if err := s.RevokeAccessToken(testCtx(), "never-issued"); err != nil {
+		t.Errorf("revoking unknown request id should be a no-op, got %v", err)
+	}
+}
+
+// ---------------------------------------------------------------- refresh token
+
+func TestRefreshTokenSession_RoundTripAndRequestIDIndex(t *testing.T) {
+	ctx := testCtx()
+	s := newStore(t, nil, nil)
+
+	if err := s.CreateRefreshTokenSession(ctx, "sig-rt-1", "sig-at-link", req("rt-req-1")); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	got, err := s.GetRefreshTokenSession(ctx, "sig-rt-1", nil)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.GetID() != "rt-req-1" {
+		t.Errorf("wrong requester id %q", got.GetID())
+	}
+	if sig := s.RefreshTokenRequestIDs["rt-req-1"]; sig != "sig-rt-1" {
+		t.Errorf("request-id index: got %q, want %q", sig, "sig-rt-1")
+	}
+
+	if err := s.DeleteRefreshTokenSession(ctx, "sig-rt-1"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if _, err := s.GetRefreshTokenSession(ctx, "sig-rt-1", nil); !errors.Is(err, fosite.ErrNotFound) {
+		t.Errorf("after delete: want ErrNotFound, got %v", err)
+	}
+}
+
+func TestGetRefreshTokenSession_NotFound(t *testing.T) {
+	s := newStore(t, nil, nil)
+	if _, err := s.GetRefreshTokenSession(testCtx(), "absent", nil); !errors.Is(err, fosite.ErrNotFound) {
+		t.Errorf("want ErrNotFound, got %v", err)
+	}
+}
+
+func TestRevokeRefreshToken_MarksInactiveSoGetReturnsErrInactiveToken(t *testing.T) {
+	ctx := testCtx()
+	s := newStore(t, nil, nil)
+	if err := s.CreateRefreshTokenSession(ctx, "sig-rt-2", "", req("rt-req-2")); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if err := s.RevokeRefreshToken(ctx, "rt-req-2"); err != nil {
+		t.Fatalf("revoke: %v", err)
+	}
+	got, err := s.GetRefreshTokenSession(ctx, "sig-rt-2", nil)
+	if !errors.Is(err, fosite.ErrInactiveToken) {
+		t.Errorf("want ErrInactiveToken after revoke, got %v", err)
+	}
+	if got == nil {
+		t.Error("revoked refresh token should still return the inactive requester")
+	}
+}
+
+func TestRevokeRefreshToken_DanglingIndexReturnsNotFound(t *testing.T) {
+	// The request-id index points at a signature that has no RefreshTokens
+	// entry (e.g. the token was deleted out of band). Revoke must surface
+	// ErrNotFound rather than silently succeeding.
+	s := newStore(t, nil, nil)
+	s.RefreshTokenRequestIDs["dangling-req"] = "missing-sig"
+	if err := s.RevokeRefreshToken(testCtx(), "dangling-req"); !errors.Is(err, fosite.ErrNotFound) {
+		t.Errorf("want ErrNotFound for dangling index, got %v", err)
+	}
+}
+
+func TestRevokeRefreshToken_UnknownRequestIDIsNoop(t *testing.T) {
+	s := newStore(t, nil, nil)
+	if err := s.RevokeRefreshToken(testCtx(), "never-issued"); err != nil {
+		t.Errorf("revoking unknown refresh request id should be a no-op, got %v", err)
+	}
+}
+
+func TestRotateRefreshToken_RevokesBothRefreshAndAccess(t *testing.T) {
+	ctx := testCtx()
+	s := newStore(t, nil, nil)
+	// Same request id ties an access token + refresh token together.
+	if err := s.CreateAccessTokenSession(ctx, "sig-at-3", req("shared-req")); err != nil {
+		t.Fatalf("create access: %v", err)
+	}
+	if err := s.CreateRefreshTokenSession(ctx, "sig-rt-3", "sig-at-3", req("shared-req")); err != nil {
+		t.Fatalf("create refresh: %v", err)
+	}
+	if err := s.RotateRefreshToken(ctx, "shared-req", "sig-rt-3"); err != nil {
+		t.Fatalf("rotate: %v", err)
+	}
+	// Refresh marked inactive ...
+	if _, err := s.GetRefreshTokenSession(ctx, "sig-rt-3", nil); !errors.Is(err, fosite.ErrInactiveToken) {
+		t.Errorf("refresh should be inactive after rotate, got %v", err)
+	}
+	// ... and the linked access token deleted.
+	if _, err := s.GetAccessTokenSession(ctx, "sig-at-3", nil); !errors.Is(err, fosite.ErrNotFound) {
+		t.Errorf("access should be deleted after rotate, got %v", err)
+	}
+}
+
+// ---------------------------------------------------------------- clients
+
+func TestSetGetClient_RoundTrip(t *testing.T) {
+	ctx := testCtx()
+	s := newStore(t, nil, nil)
+	c := NewKubauthClient(sampleOidcClient(), "client-a", nil)
+
+	if err := s.SetClient(ctx, c); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	got, err := s.GetKubauthClient(ctx, "client-a")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.GetID() != "client-a" {
+		t.Errorf("wrong client id %q", got.GetID())
+	}
+	// GetClient is the fosite.ClientManager adapter and must return the same client.
+	fc, err := s.GetClient(ctx, "client-a")
+	if err != nil {
+		t.Fatalf("GetClient: %v", err)
+	}
+	if fc.GetID() != "client-a" {
+		t.Errorf("GetClient wrong id %q", fc.GetID())
+	}
+}
+
+func TestGetKubauthClient_NotFound(t *testing.T) {
+	s := newStore(t, nil, nil)
+	got, err := s.GetKubauthClient(testCtx(), "missing")
+	if !errors.Is(err, fosite.ErrNotFound) {
+		t.Errorf("want ErrNotFound, got %v", err)
+	}
+	if got != nil {
+		t.Errorf("want nil client, got %v", got)
+	}
+}
+
+func TestGetClient_NotFound(t *testing.T) {
+	s := newStore(t, nil, nil)
+	if _, err := s.GetClient(testCtx(), "missing"); !errors.Is(err, fosite.ErrNotFound) {
+		t.Errorf("want ErrNotFound, got %v", err)
+	}
+}
+
+func TestSetClient_SameK8sIdOverwrites(t *testing.T) {
+	ctx := testCtx()
+	s := newStore(t, nil, nil)
+	// Re-applying the *same* CR (same namespace:name) under the same client_id
+	// must overwrite, not error.
+	if err := s.SetClient(ctx, NewKubauthClient(sampleOidcClient(), "dup", nil)); err != nil {
+		t.Fatalf("first set: %v", err)
+	}
+	if err := s.SetClient(ctx, NewKubauthClient(sampleOidcClient(), "dup", nil)); err != nil {
+		t.Errorf("re-set with identical k8sId should succeed, got %v", err)
+	}
+}
+
+func TestSetClient_DifferentK8sIdSameClientIdIsDuplicationError(t *testing.T) {
+	ctx := testCtx()
+	s := newStore(t, nil, nil)
+	if err := s.SetClient(ctx, NewKubauthClient(sampleOidcClient(), "shared-id", nil)); err != nil {
+		t.Fatalf("first set: %v", err)
+	}
+	// Same client_id but a CR from a different namespace -> collision.
+	other := sampleOidcClient()
+	other.Namespace = "other-namespace"
+	err := s.SetClient(ctx, NewKubauthClient(other, "shared-id", nil))
+	if err == nil {
+		t.Fatal("expected ClientDuplicationError, got nil")
+	}
+	var dup *ClientDuplicationError
+	if !errors.As(err, &dup) {
+		t.Fatalf("want *ClientDuplicationError, got %T (%v)", err, err)
+	}
+	if dup.GetExistingClient() != "kubauth-system:smoke-client" {
+		t.Errorf("duplication error names wrong existing client: %q", dup.GetExistingClient())
+	}
+}
+
+func TestDeleteClient_RemovesAndIsIdempotent(t *testing.T) {
+	ctx := testCtx()
+	s := newStore(t, nil, nil)
+	if err := s.SetClient(ctx, NewKubauthClient(sampleOidcClient(), "del-me", nil)); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	s.DeleteClient(ctx, "del-me")
+	if _, err := s.GetKubauthClient(ctx, "del-me"); !errors.Is(err, fosite.ErrNotFound) {
+		t.Errorf("after delete: want ErrNotFound, got %v", err)
+	}
+	// Deleting again must not panic.
+	s.DeleteClient(ctx, "del-me")
+}
+
+// ---------------------------------------------------------------- token lifespans
+
+func TestSetTokenLifespans_NotFound(t *testing.T) {
+	s := newStore(t, nil, nil)
+	if err := s.SetTokenLifespans("no-such-client", &fosite.ClientLifespanConfig{}); !errors.Is(err, fosite.ErrNotFound) {
+		t.Errorf("want ErrNotFound for unknown client, got %v", err)
+	}
+}
+
+func TestSetTokenLifespans_WrongClientTypeReturnsError(t *testing.T) {
+	// kubauthClient implements fosite.Client but is not a
+	// *fosite.DefaultClientWithCustomTokenLifespans, so the type assertion in
+	// SetTokenLifespans fails and an error (not nil, not ErrNotFound) is returned.
+	ctx := testCtx()
+	s := newStore(t, nil, nil)
+	if err := s.SetClient(ctx, NewKubauthClient(sampleOidcClient(), "wrong-type", nil)); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	err := s.SetTokenLifespans("wrong-type", &fosite.ClientLifespanConfig{})
+	if err == nil {
+		t.Fatal("expected a type-assertion error, got nil")
+	}
+	if errors.Is(err, fosite.ErrNotFound) {
+		t.Errorf("expected type-assertion error, not ErrNotFound: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------- JTI blacklist
+
+func TestClientAssertionJWT_SetThenKnownIsRejected(t *testing.T) {
+	ctx := testCtx()
+	s := newStore(t, nil, nil)
+
+	// Unknown JTI is valid.
+	if err := s.ClientAssertionJWTValid(ctx, "jti-1"); err != nil {
+		t.Fatalf("fresh jti should be valid, got %v", err)
+	}
+	// Blacklist it with a future expiry.
+	if err := s.SetClientAssertionJWT(ctx, "jti-1", time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("set jwt: %v", err)
+	}
+	// Now it is known -> rejected.
+	if err := s.ClientAssertionJWTValid(ctx, "jti-1"); !errors.Is(err, fosite.ErrJTIKnown) {
+		t.Errorf("blacklisted jti: want ErrJTIKnown, got %v", err)
+	}
+	// Re-setting a still-live JTI is itself an ErrJTIKnown.
+	if err := s.SetClientAssertionJWT(ctx, "jti-1", time.Now().Add(time.Hour)); !errors.Is(err, fosite.ErrJTIKnown) {
+		t.Errorf("re-setting live jti: want ErrJTIKnown, got %v", err)
+	}
+}
+
+func TestClientAssertionJWTValid_ExpiredEntryIsValidAgain(t *testing.T) {
+	ctx := testCtx()
+	s := newStore(t, nil, nil)
+	// An already-expired blacklist entry must not reject the JTI.
+	if err := s.SetClientAssertionJWT(ctx, "jti-exp", time.Now().Add(-time.Minute)); err != nil {
+		t.Fatalf("set jwt: %v", err)
+	}
+	if err := s.ClientAssertionJWTValid(ctx, "jti-exp"); err != nil {
+		t.Errorf("expired jti should validate, got %v", err)
+	}
+}
+
+func TestSetClientAssertionJWT_PrunesExpiredEntries(t *testing.T) {
+	ctx := testCtx()
+	s := newStore(t, nil, nil)
+	// Seed an expired entry directly, then add a fresh one: the set call prunes
+	// expired entries as a side effect.
+	s.BlacklistedJTIs["stale"] = time.Now().Add(-time.Hour)
+	if err := s.SetClientAssertionJWT(ctx, "fresh", time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	if _, ok := s.BlacklistedJTIs["stale"]; ok {
+		t.Error("expired entry should have been pruned")
+	}
+	if _, ok := s.BlacklistedJTIs["fresh"]; !ok {
+		t.Error("fresh entry should be present")
+	}
+}
+
+func TestIsJWTUsed_TracksMarkJWTUsedForTime(t *testing.T) {
+	ctx := testCtx()
+	s := newStore(t, nil, nil)
+
+	used, err := s.IsJWTUsed(ctx, "jti-used")
+	if err != nil {
+		t.Fatalf("IsJWTUsed: %v", err)
+	}
+	if used {
+		t.Error("fresh jti should report not used")
+	}
+	if err := s.MarkJWTUsedForTime(ctx, "jti-used", time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("mark: %v", err)
+	}
+	used, err = s.IsJWTUsed(ctx, "jti-used")
+	if err != nil {
+		t.Fatalf("IsJWTUsed (2): %v", err)
+	}
+	if !used {
+		t.Error("after MarkJWTUsedForTime the jti must report used")
+	}
+}
+
+// ---------------------------------------------------------------- PAR sessions
+
+func TestPARSession_RoundTrip(t *testing.T) {
+	ctx := testCtx()
+	s := newStore(t, nil, nil)
+	ar := fosite.NewAuthorizeRequest()
+	ar.SetID("par-req-1")
+
+	if err := s.CreatePARSession(ctx, "urn:req:1", ar); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	got, err := s.GetPARSession(ctx, "urn:req:1")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.GetID() != "par-req-1" {
+		t.Errorf("wrong PAR requester id %q", got.GetID())
+	}
+
+	if err := s.DeletePARSession(ctx, "urn:req:1"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if _, err := s.GetPARSession(ctx, "urn:req:1"); !errors.Is(err, fosite.ErrNotFound) {
+		t.Errorf("after delete: want ErrNotFound, got %v", err)
+	}
+}
+
+func TestGetPARSession_NotFound(t *testing.T) {
+	s := newStore(t, nil, nil)
+	got, err := s.GetPARSession(testCtx(), "urn:absent")
+	if !errors.Is(err, fosite.ErrNotFound) {
+		t.Errorf("want ErrNotFound, got %v", err)
+	}
+	if got != nil {
+		t.Errorf("want nil on miss, got %v", got)
+	}
+}
+
+func TestDeletePARSession_MissingIsNoop(t *testing.T) {
+	s := newStore(t, nil, nil)
+	if err := s.DeletePARSession(testCtx(), "urn:absent"); err != nil {
+		t.Errorf("deleting absent PAR session should be no-op, got %v", err)
+	}
+}
+
+// ---------------------------------------------------------------- upstreams
+
+func TestUpstream_SetGetDeleteRoundTrip(t *testing.T) {
+	ctx := testCtx()
+	s := newStore(t, nil, nil)
+	up := internalUpstream(t, "up-a")
+
+	s.SetUpstream(ctx, up)
+	got := s.GetUpstream(ctx, "up-a")
+	if got == nil {
+		t.Fatal("GetUpstream returned nil after SetUpstream")
+	}
+	if got.GetName() != "up-a" {
+		t.Errorf("wrong upstream name %q", got.GetName())
+	}
+
+	s.DeleteUpstream(ctx, "up-a")
+	if got := s.GetUpstream(ctx, "up-a"); got != nil {
+		t.Errorf("after delete: want nil, got %v", got)
+	}
+}
+
+func TestGetUpstream_MissingReturnsNil(t *testing.T) {
+	s := newStore(t, nil, nil)
+	if got := s.GetUpstream(testCtx(), "nope"); got != nil {
+		t.Errorf("missing upstream: want nil, got %v", got)
+	}
+}
+
+func TestGetUpstreams_ReturnsAllStored(t *testing.T) {
+	ctx := testCtx()
+	s := newStore(t, nil, nil)
+	s.SetUpstream(ctx, internalUpstream(t, "u1"))
+	s.SetUpstream(ctx, internalUpstream(t, "u2"))
+
+	all := s.GetUpstreams(ctx)
+	if len(all) != 2 {
+		t.Fatalf("want 2 upstreams, got %d", len(all))
+	}
+	names := map[string]bool{}
+	for _, u := range all {
+		names[u.GetName()] = true
+	}
+	if !names["u1"] || !names["u2"] {
+		t.Errorf("missing upstreams in result: %v", names)
+	}
+}
+
+func TestGetUpstreams_EmptyStoreReturnsEmpty(t *testing.T) {
+	s := newStore(t, nil, nil)
+	if all := s.GetUpstreams(testCtx()); len(all) != 0 {
+		t.Errorf("empty store: want 0 upstreams, got %d", len(all))
+	}
+}
+
+func TestDeleteUpstream_MissingIsNoop(t *testing.T) {
+	s := newStore(t, nil, nil)
+	s.DeleteUpstream(testCtx(), "absent") // must not panic
+}
+
+// ---------------------------------------------------------------- authenticate
+
+func TestAuthenticate_ReturnsLoginOnSuccess(t *testing.T) {
+	s := newStore(t, &authenticator.OidcUser{Login: "alice"}, nil)
+	sub, err := s.Authenticate(testCtx(), "alice", "pw")
+	if err != nil {
+		t.Fatalf("authenticate: %v", err)
+	}
+	if sub != "alice" {
+		t.Errorf("subject: got %q, want alice", sub)
+	}
+}
+
+func TestAuthenticate_PropagatesErrorAndEmptySubject(t *testing.T) {
+	wantErr := errors.New("bad creds")
+	s := newStore(t, nil, wantErr)
+	sub, err := s.Authenticate(testCtx(), "alice", "wrong")
+	if !errors.Is(err, wantErr) {
+		t.Errorf("want propagated auth error, got %v", err)
+	}
+	if sub != "" {
+		t.Errorf("subject should be empty on failure, got %q", sub)
+	}
+}
+
+func TestAuthenticateUserWithClaims_ReturnsFullUser(t *testing.T) {
+	user := &authenticator.OidcUser{
+		Login:    "bob",
+		FullName: "Bob Builder",
+		Claims:   map[string]interface{}{"email": "bob@example.com"},
+	}
+	s := newStore(t, user, nil)
+	got, err := s.AuthenticateUserWithClaims(testCtx(), "bob", "pw")
+	if err != nil {
+		t.Fatalf("authenticate with claims: %v", err)
+	}
+	if got == nil || got.Login != "bob" || got.FullName != "Bob Builder" {
+		t.Fatalf("unexpected user %+v", got)
+	}
+	if got.Claims["email"] != "bob@example.com" {
+		t.Errorf("claims not carried through: %v", got.Claims)
+	}
+}
+
+func TestAuthenticateUserWithClaims_PropagatesError(t *testing.T) {
+	wantErr := errors.New("nope")
+	s := newStore(t, nil, wantErr)
+	if _, err := s.AuthenticateUserWithClaims(testCtx(), "x", "y"); !errors.Is(err, wantErr) {
+		t.Errorf("want propagated error, got %v", err)
+	}
+}
+
+// ---------------------------------------------------------------- config getters
+
+func TestConfigGetters(t *testing.T) {
+	s := newStore(t, nil, nil)
+	s.Issuer = "https://issuer.example"
+	s.KeyID = "kid-7"
+	s.AllowPasswordGrant = true
+
+	if s.GetIssuer() != "https://issuer.example" {
+		t.Errorf("GetIssuer: %q", s.GetIssuer())
+	}
+	if s.GetKeyID() != "kid-7" {
+		t.Errorf("GetKeyID: %q", s.GetKeyID())
+	}
+	if !s.IsAllowPasswordGrant() {
+		t.Error("IsAllowPasswordGrant: want true")
+	}
+}
+
+func TestIsAllowPasswordGrant_DefaultFalse(t *testing.T) {
+	s := newStore(t, nil, nil)
+	if s.IsAllowPasswordGrant() {
+		t.Error("default AllowPasswordGrant should be false")
+	}
+}
+
+// ---------------------------------------------------------------- public keys
+
+// jtiKey builds a tiny RSA JWK keyed by keyID with the given scopes and wires it
+// into the store's IssuerPublicKeys nested maps under issuer/subject.
+func seedPublicKey(t *testing.T, s *MemoryStore, issuer, subject, keyID string, scopes []string) {
+	t.Helper()
+	jwk := newJWK(t, keyID)
+	s.IssuerPublicKeys[issuer] = IssuerPublicKeys{
+		Issuer: issuer,
+		KeysBySub: map[string]SubjectPublicKeys{
+			subject: {
+				Subject: subject,
+				Keys: map[string]PublicKeyScopes{
+					keyID: {Key: jwk, Scopes: scopes},
+				},
+			},
+		},
+	}
+}
+
+func TestGetPublicKey_FoundAndNotFound(t *testing.T) {
+	s := newStore(t, nil, nil)
+	seedPublicKey(t, s, "iss", "sub", "k1", []string{"read"})
+
+	got, err := s.GetPublicKey(testCtx(), "iss", "sub", "k1")
+	if err != nil {
+		t.Fatalf("get public key: %v", err)
+	}
+	if got == nil || got.KeyID != "k1" {
+		t.Fatalf("unexpected key %+v", got)
+	}
+	// Wrong key id / subject / issuer all yield ErrNotFound.
+	for _, tc := range []struct{ iss, sub, kid string }{
+		{"iss", "sub", "missing-kid"},
+		{"iss", "missing-sub", "k1"},
+		{"missing-iss", "sub", "k1"},
+	} {
+		if _, err := s.GetPublicKey(testCtx(), tc.iss, tc.sub, tc.kid); !errors.Is(err, fosite.ErrNotFound) {
+			t.Errorf("GetPublicKey(%v): want ErrNotFound, got %v", tc, err)
+		}
+	}
+}
+
+func TestGetPublicKeys_ReturnsKeySetAndNotFound(t *testing.T) {
+	s := newStore(t, nil, nil)
+	seedPublicKey(t, s, "iss", "sub", "k1", nil)
+
+	set, err := s.GetPublicKeys(testCtx(), "iss", "sub")
+	if err != nil {
+		t.Fatalf("get public keys: %v", err)
+	}
+	if set == nil || len(set.Keys) != 1 || set.Keys[0].KeyID != "k1" {
+		t.Fatalf("unexpected key set %+v", set)
+	}
+	if _, err := s.GetPublicKeys(testCtx(), "iss", "missing"); !errors.Is(err, fosite.ErrNotFound) {
+		t.Errorf("missing subject: want ErrNotFound, got %v", err)
+	}
+}
+
+func TestGetPublicKeys_SubjectWithNoKeysIsNotFound(t *testing.T) {
+	// A subject entry that exists but carries an empty key map must be treated
+	// as not-found rather than returning an empty key set.
+	s := newStore(t, nil, nil)
+	s.IssuerPublicKeys["iss"] = IssuerPublicKeys{
+		Issuer: "iss",
+		KeysBySub: map[string]SubjectPublicKeys{
+			"sub": {Subject: "sub", Keys: map[string]PublicKeyScopes{}},
+		},
+	}
+	if _, err := s.GetPublicKeys(testCtx(), "iss", "sub"); !errors.Is(err, fosite.ErrNotFound) {
+		t.Errorf("subject with no keys: want ErrNotFound, got %v", err)
+	}
+}
+
+func TestGetPublicKeyScopes_FoundAndNotFound(t *testing.T) {
+	s := newStore(t, nil, nil)
+	seedPublicKey(t, s, "iss", "sub", "k1", []string{"read", "write"})
+
+	scopes, err := s.GetPublicKeyScopes(testCtx(), "iss", "sub", "k1")
+	if err != nil {
+		t.Fatalf("get scopes: %v", err)
+	}
+	if len(scopes) != 2 || scopes[0] != "read" || scopes[1] != "write" {
+		t.Errorf("unexpected scopes %v", scopes)
+	}
+	if _, err := s.GetPublicKeyScopes(testCtx(), "iss", "sub", "missing"); !errors.Is(err, fosite.ErrNotFound) {
+		t.Errorf("missing key id: want ErrNotFound, got %v", err)
+	}
+}
+
+// ---------------------------------------------------------------- self-providers
+
+func TestStorageProviderAccessors_ReturnSelf(t *testing.T) {
+	// The fosite.Storage facade methods must all hand back the store itself,
+	// since MemoryStore implements every sub-storage interface.
+	s := newStore(t, nil, nil)
+	if s.ClientManager() != s {
+		t.Error("ClientManager should return self")
+	}
+	if s.AccessTokenStorage() != s {
+		t.Error("AccessTokenStorage should return self")
+	}
+	if s.RefreshTokenStorage() != s {
+		t.Error("RefreshTokenStorage should return self")
+	}
+	if s.AuthorizeCodeStorage() != s {
+		t.Error("AuthorizeCodeStorage should return self")
+	}
+	if s.OpenIDConnectRequestStorage() != s {
+		t.Error("OpenIDConnectRequestStorage should return self")
+	}
+	if s.PKCERequestStorage() != s {
+		t.Error("PKCERequestStorage should return self")
+	}
+	if s.PARStorage() != s {
+		t.Error("PARStorage should return self")
+	}
+	if s.TokenRevocationStorage() != s {
+		t.Error("TokenRevocationStorage should return self")
+	}
+	if s.RFC7523KeyStorage() != s {
+		t.Error("RFC7523KeyStorage should return self")
+	}
+}

--- a/cmd/oidc/sessioncodec/jsoncodec_test.go
+++ b/cmd/oidc/sessioncodec/jsoncodec_test.go
@@ -1,0 +1,129 @@
+/*
+Copyright (c) 2025 Kubotal.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package sessioncodec
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestJSONCodec_RoundTripPreservesDeadlineAndValues(t *testing.T) {
+	deadline := time.Date(2025, 12, 31, 23, 59, 59, 0, time.UTC)
+	values := map[string]interface{}{
+		"login":   "alice",
+		"groups":  []interface{}{"admin", "users"},
+		"counter": float64(42), // JSON numbers decode as float64
+	}
+
+	codec := JSONCodec{}
+	encoded, err := codec.Encode(deadline, values)
+	if err != nil {
+		t.Fatalf("Encode error: %v", err)
+	}
+	if len(encoded) == 0 {
+		t.Fatalf("Encode produced empty payload")
+	}
+
+	gotDeadline, gotValues, err := codec.Decode(encoded)
+	if err != nil {
+		t.Fatalf("Decode error: %v", err)
+	}
+	if !gotDeadline.Equal(deadline) {
+		t.Errorf("deadline mismatch: got %v, want %v", gotDeadline, deadline)
+	}
+	if !reflect.DeepEqual(gotValues, values) {
+		t.Errorf("values mismatch:\n got  %v\n want %v", gotValues, values)
+	}
+}
+
+func TestJSONCodec_DecodeEmptyBytesReturnsZeroDeadlineAndEmptyMap(t *testing.T) {
+	codec := JSONCodec{}
+	gotDeadline, gotValues, err := codec.Decode(nil)
+	if err != nil {
+		t.Fatalf("Decode(nil) returned error: %v", err)
+	}
+	if !gotDeadline.IsZero() {
+		t.Errorf("Decode(nil) deadline should be zero, got %v", gotDeadline)
+	}
+	if gotValues == nil {
+		t.Errorf("Decode(nil) values should be empty map, not nil")
+	}
+	if len(gotValues) != 0 {
+		t.Errorf("Decode(nil) values should be empty, got %v", gotValues)
+	}
+
+	// Same expectations for an empty-byte slice (distinct from nil in Go).
+	gotDeadline, gotValues, err = codec.Decode([]byte{})
+	if err != nil {
+		t.Fatalf("Decode([]) returned error: %v", err)
+	}
+	if !gotDeadline.IsZero() {
+		t.Errorf("Decode([]) deadline should be zero, got %v", gotDeadline)
+	}
+	if gotValues == nil || len(gotValues) != 0 {
+		t.Errorf("Decode([]) values should be empty map, got %v", gotValues)
+	}
+}
+
+func TestJSONCodec_DecodeInvalidJSONErrors(t *testing.T) {
+	codec := JSONCodec{}
+	_, _, err := codec.Decode([]byte("not-valid-json{{"))
+	if err == nil {
+		t.Errorf("Decode of invalid JSON should error")
+	}
+}
+
+func TestJSONCodec_DecodeNilValuesYieldsEmptyMap(t *testing.T) {
+	// Hand-craft a payload where Values is JSON null — Decode must
+	// normalise to an empty (non-nil) map so downstream
+	// `session.Get(...)` is safe to call.
+	codec := JSONCodec{}
+	payload := []byte(`{"deadline":"2025-01-01T00:00:00Z","values":null}`)
+	_, gotValues, err := codec.Decode(payload)
+	if err != nil {
+		t.Fatalf("Decode error: %v", err)
+	}
+	if gotValues == nil {
+		t.Errorf("expected empty map for null values, got nil")
+	}
+	if len(gotValues) != 0 {
+		t.Errorf("expected empty map for null values, got %v", gotValues)
+	}
+}
+
+func TestJSONCodec_EncodeNilValuesDoesNotPanic(t *testing.T) {
+	codec := JSONCodec{}
+	deadline := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	encoded, err := codec.Encode(deadline, nil)
+	if err != nil {
+		t.Fatalf("Encode(nil values) error: %v", err)
+	}
+	// Round-trip and confirm Decode normalises back to empty map.
+	_, gotValues, err := codec.Decode(encoded)
+	if err != nil {
+		t.Fatalf("Decode error: %v", err)
+	}
+	if gotValues == nil || len(gotValues) != 0 {
+		t.Errorf("expected empty map after round-trip from nil, got %v", gotValues)
+	}
+}
+
+func TestJSONCodec_EncodeProducesValidJSON(t *testing.T) {
+	codec := JSONCodec{}
+	deadline := time.Date(2025, 6, 15, 12, 0, 0, 0, time.UTC)
+	values := map[string]interface{}{"key": "value"}
+	encoded, err := codec.Encode(deadline, values)
+	if err != nil {
+		t.Fatalf("Encode error: %v", err)
+	}
+	// Sanity: must be ASCII JSON object starting with {.
+	if len(encoded) < 2 || encoded[0] != '{' || encoded[len(encoded)-1] != '}' {
+		t.Errorf("encoded payload doesn't look like a JSON object: %s", encoded)
+	}
+}

--- a/cmd/oidc/sessionstore/kubessostore.go
+++ b/cmd/oidc/sessionstore/kubessostore.go
@@ -21,6 +21,8 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"log/slog"
+
 	kubauthv1alpha1 "kubauth/api/kubauth/v1alpha1"
 	"time"
 
@@ -43,6 +45,17 @@ func NewKubeSsoStore(k8sClient client.Client, namespace string) *KubeSsoStore {
 	return &KubeSsoStore{client: k8sClient, namespace: namespace}
 }
 
+// loggerFrom returns the slog logger carried by ctx, or slog.Default() when none
+// is set. The non-Ctx Find/Commit/Delete/All wrappers call the *Ctx methods with a
+// bare context.Background(); without this fallback the logger.* calls would panic
+// on a nil logger.
+func loggerFrom(ctx context.Context) *slog.Logger {
+	if l := logr.FromContextAsSlogLogger(ctx); l != nil {
+		return l
+	}
+	return slog.Default()
+}
+
 const annotationRawSession = "kubauth.kubotal.io/session"
 
 type sessionEnvelope struct {
@@ -59,7 +72,7 @@ func (s *KubeSsoStore) Find(token string) ([]byte, bool, error) {
 func (s *KubeSsoStore) FindCtx(ctx context.Context, token string) ([]byte, bool, error) {
 	var sess kubauthv1alpha1.SsoSession
 	name := encodeName(token)
-	logger := logr.FromContextAsSlogLogger(ctx)
+	logger := loggerFrom(ctx)
 	if err := s.client.Get(ctx, types.NamespacedName{Namespace: s.namespace, Name: name}, &sess); err != nil {
 		logger.Debug("SsoSession not found", "token", token, "encoded", name)
 		return nil, false, client.IgnoreNotFound(err)
@@ -85,7 +98,7 @@ func (s *KubeSsoStore) Commit(token string, b []byte, expiry time.Time) error {
 // CommitCtx stores or updates the SsoSession resource using provided context.
 func (s *KubeSsoStore) CommitCtx(ctx context.Context, token string, b []byte, expiry time.Time) error {
 	// Decode the envelope to extract mirrored fields
-	logger := logr.FromContextAsSlogLogger(ctx)
+	logger := loggerFrom(ctx)
 	var env sessionEnvelope
 	if len(b) > 0 {
 		if err := json.Unmarshal(b, &env); err != nil {
@@ -148,7 +161,9 @@ func (s *KubeSsoStore) CommitCtx(ctx context.Context, token string, b []byte, ex
 		existing.Spec.Claims = nil
 	}
 	err = s.client.Update(ctx, &existing)
-	logger.Error("Failed to update SSO session", "error", err)
+	if err != nil {
+		logger.Error("Failed to update SSO session", "error", err)
+	}
 	return err
 }
 
@@ -160,7 +175,7 @@ func (s *KubeSsoStore) Delete(token string) error {
 // DeleteCtx removes the SsoSession resource using provided context.
 func (s *KubeSsoStore) DeleteCtx(ctx context.Context, token string) error {
 	name := encodeName(token)
-	logger := logr.FromContextAsSlogLogger(ctx)
+	logger := loggerFrom(ctx)
 	logger.Debug("Deleting session", "token", token, "encoded", name)
 	return s.client.Delete(ctx, &kubauthv1alpha1.SsoSession{ObjectMeta: metav1.ObjectMeta{Namespace: s.namespace, Name: name}})
 }
@@ -182,7 +197,7 @@ func (s *KubeSsoStore) AllCtx(ctx context.Context) ([]string, error) {
 			res = append(res, t)
 		}
 	}
-	logger := logr.FromContextAsSlogLogger(ctx)
+	logger := loggerFrom(ctx)
 	logger.Debug("Listing sessions", "count", len(res))
 
 	return res, nil

--- a/cmd/oidc/sessionstore/kubessostore_test.go
+++ b/cmd/oidc/sessionstore/kubessostore_test.go
@@ -1,0 +1,381 @@
+/*
+Copyright (c) 2025 Kubotal.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package sessionstore
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	kubauthv1alpha1 "kubauth/api/kubauth/v1alpha1"
+
+	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// testCtx returns a context wired with a discard slog logger — required
+// by KubeSsoStore methods, which call `logr.FromContextAsSlogLogger(ctx)`
+// and panic on nil. Replaces plain `context.Background()` everywhere
+// in this file.
+func testCtx() context.Context {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	return logr.NewContextWithSlogLogger(context.Background(), logger)
+}
+
+// helpers ----------------------------------------------------------------
+
+const testNS = "kubauth-system"
+
+func newStore(t *testing.T, seed ...client.Object) (*KubeSsoStore, client.Client) {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := kubauthv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(seed...).Build()
+	return NewKubeSsoStore(c, testNS), c
+}
+
+func envelopeBytes(t *testing.T, login string, claims map[string]interface{}, fullName string) []byte {
+	t.Helper()
+	env := sessionEnvelope{
+		Deadline: time.Now().Add(time.Hour),
+		Values: map[string]interface{}{
+			"ssoUser": map[string]interface{}{
+				"Login":    login,
+				"Claims":   claims,
+				"FullName": fullName,
+			},
+		},
+	}
+	b, err := json.Marshal(env)
+	if err != nil {
+		t.Fatalf("marshal envelope: %v", err)
+	}
+	return b
+}
+
+// CommitCtx --------------------------------------------------------------
+
+func TestCommitCtx_CreatesSsoSessionWithMirroredFields(t *testing.T) {
+	store, c := newStore(t)
+	ctx := testCtx()
+	expiry := time.Now().Add(2 * time.Hour)
+
+	if err := store.CommitCtx(ctx, "tok-1", envelopeBytes(t, "alice", map[string]interface{}{"sub": "alice"}, "Alice Wonderland"), expiry); err != nil {
+		t.Fatalf("CommitCtx: %v", err)
+	}
+
+	var got kubauthv1alpha1.SsoSession
+	if err := c.Get(ctx, types.NamespacedName{Namespace: testNS, Name: encodeName("tok-1")}, &got); err != nil {
+		t.Fatalf("get created session: %v", err)
+	}
+	if got.Spec.Login != "alice" {
+		t.Errorf("login mirrored: got %q", got.Spec.Login)
+	}
+	if got.Spec.FullName != "Alice Wonderland" {
+		t.Errorf("fullName mirrored: got %q", got.Spec.FullName)
+	}
+	if got.Spec.WebToken != "tok-1" {
+		t.Errorf("webToken mirrored: got %q", got.Spec.WebToken)
+	}
+	if got.Annotations[annotationRawSession] == "" {
+		t.Error("raw session annotation must be set")
+	}
+}
+
+func TestCommitCtx_EmptyLoginSkipsStore(t *testing.T) {
+	// `extractUser` returning "" login → CommitCtx returns nil without
+	// creating anything. Useful for unauthenticated browser sessions.
+	store, c := newStore(t)
+	ctx := testCtx()
+
+	// Envelope with Values containing no recognisable user.
+	env := sessionEnvelope{Values: map[string]interface{}{"foo": "bar"}}
+	b, _ := json.Marshal(env)
+
+	if err := store.CommitCtx(ctx, "tok-empty", b, time.Now()); err != nil {
+		t.Fatalf("CommitCtx on empty user: %v", err)
+	}
+
+	var list kubauthv1alpha1.SsoSessionList
+	_ = c.List(ctx, &list)
+	if len(list.Items) != 0 {
+		t.Errorf("no session should have been created, got %d", len(list.Items))
+	}
+}
+
+func TestCommitCtx_UpdatesExisting(t *testing.T) {
+	// First commit creates; second commit on the same token updates
+	// the same SsoSession object (same name, no duplicate created).
+	store, c := newStore(t)
+	ctx := testCtx()
+
+	if err := store.CommitCtx(ctx, "tok-2", envelopeBytes(t, "alice", nil, "Alice"), time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("first commit: %v", err)
+	}
+	if err := store.CommitCtx(ctx, "tok-2", envelopeBytes(t, "alice", nil, "Alice Updated"), time.Now().Add(2*time.Hour)); err != nil {
+		t.Fatalf("second commit: %v", err)
+	}
+
+	var list kubauthv1alpha1.SsoSessionList
+	if err := c.List(ctx, &list); err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(list.Items) != 1 {
+		t.Fatalf("expected exactly 1 session after update, got %d", len(list.Items))
+	}
+	if list.Items[0].Spec.FullName != "Alice Updated" {
+		t.Errorf("update didn't propagate: %q", list.Items[0].Spec.FullName)
+	}
+}
+
+func TestCommitCtx_InvalidJSONErrors(t *testing.T) {
+	store, _ := newStore(t)
+	if err := store.CommitCtx(testCtx(), "tok-bad", []byte("{not json"), time.Now()); err == nil {
+		t.Error("expected error on invalid JSON")
+	}
+}
+
+// FindCtx ----------------------------------------------------------------
+
+func TestFindCtx_RoundTripPreservesRawBytes(t *testing.T) {
+	store, _ := newStore(t)
+	ctx := testCtx()
+	raw := envelopeBytes(t, "alice", nil, "Alice")
+
+	if err := store.CommitCtx(ctx, "tok-rt", raw, time.Now().Add(time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+	got, found, err := store.FindCtx(ctx, "tok-rt")
+	if err != nil {
+		t.Fatalf("FindCtx: %v", err)
+	}
+	if !found {
+		t.Fatal("expected found=true")
+	}
+	if !reflect.DeepEqual(got, raw) {
+		t.Errorf("raw bytes not preserved\n got:  %s\n want: %s", got, raw)
+	}
+}
+
+func TestFindCtx_MissingTokenReturnsNotFound(t *testing.T) {
+	store, _ := newStore(t)
+	got, found, err := store.FindCtx(testCtx(), "no-such-token")
+	if err != nil {
+		t.Fatalf("FindCtx of missing token should not error: %v", err)
+	}
+	if found {
+		t.Error("expected found=false")
+	}
+	if got != nil {
+		t.Errorf("expected nil bytes, got %v", got)
+	}
+}
+
+func TestFindCtx_SessionWithoutAnnotationReturnsNotFound(t *testing.T) {
+	// An SsoSession that exists but lacks the kubauth annotation —
+	// could happen if someone hand-creates a CRD. Should treat as
+	// "no session" so the SCS layer creates a fresh one.
+	store, _ := newStore(t, &kubauthv1alpha1.SsoSession{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNS,
+			Name:      encodeName("tok-bare"),
+			// no annotations at all
+		},
+	})
+	_, found, err := store.FindCtx(testCtx(), "tok-bare")
+	if err != nil {
+		t.Fatalf("FindCtx: %v", err)
+	}
+	if found {
+		t.Error("session without raw-session annotation should be treated as not-found")
+	}
+}
+
+// DeleteCtx --------------------------------------------------------------
+
+func TestDeleteCtx_RemovesSession(t *testing.T) {
+	store, c := newStore(t)
+	ctx := testCtx()
+
+	_ = store.CommitCtx(ctx, "tok-del", envelopeBytes(t, "alice", nil, ""), time.Now().Add(time.Hour))
+	if err := store.DeleteCtx(ctx, "tok-del"); err != nil {
+		t.Fatalf("DeleteCtx: %v", err)
+	}
+
+	var got kubauthv1alpha1.SsoSession
+	err := c.Get(ctx, types.NamespacedName{Namespace: testNS, Name: encodeName("tok-del")}, &got)
+	if err == nil {
+		t.Error("expected NotFound after Delete, got existing session")
+	}
+}
+
+// AllCtx -----------------------------------------------------------------
+
+func TestAllCtx_ReturnsWebTokensInNamespace(t *testing.T) {
+	store, _ := newStore(t)
+	ctx := testCtx()
+	for _, tok := range []string{"tok-A", "tok-B", "tok-C"} {
+		_ = store.CommitCtx(ctx, tok, envelopeBytes(t, "alice", nil, ""), time.Now().Add(time.Hour))
+	}
+	got, err := store.AllCtx(ctx)
+	if err != nil {
+		t.Fatalf("AllCtx: %v", err)
+	}
+	if len(got) != 3 {
+		t.Errorf("expected 3 tokens, got %d: %v", len(got), got)
+	}
+	have := map[string]bool{}
+	for _, t := range got {
+		have[t] = true
+	}
+	for _, want := range []string{"tok-A", "tok-B", "tok-C"} {
+		if !have[want] {
+			t.Errorf("missing token: %q", want)
+		}
+	}
+}
+
+func TestAllCtx_EmptyNamespaceReturnsEmpty(t *testing.T) {
+	store, _ := newStore(t)
+	got, err := store.AllCtx(testCtx())
+	if err != nil {
+		t.Fatalf("AllCtx: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected empty list, got %v", got)
+	}
+}
+
+func TestAllCtx_SkipsSessionsWithoutWebToken(t *testing.T) {
+	// Sessions without spec.webToken (older or hand-crafted) shouldn't
+	// surface in All() — there's no usable token to return.
+	store, _ := newStore(t, &kubauthv1alpha1.SsoSession{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNS,
+			Name:      "without-token",
+		},
+		Spec: kubauthv1alpha1.SsoSessionSpec{
+			Login:    "alice",
+			Deadline: metav1.NewTime(time.Now().Add(time.Hour)),
+			Expiry:   metav1.NewTime(time.Now().Add(time.Hour)),
+			// no WebToken
+		},
+	})
+	got, err := store.AllCtx(testCtx())
+	if err != nil {
+		t.Fatalf("AllCtx: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected empty list (the session has no webToken), got %v", got)
+	}
+}
+
+// extractUser ------------------------------------------------------------
+
+func TestExtractUser_PrefersSsoUserKey(t *testing.T) {
+	values := map[string]interface{}{
+		"ssoUser": map[string]interface{}{"Login": "alice", "FullName": "Alice"},
+		"other":   map[string]interface{}{"Login": "bob"},
+	}
+	login, _, fullName := extractUser(values)
+	if login != "alice" || fullName != "Alice" {
+		t.Errorf("ssoUser key not preferred: login=%q fullName=%q", login, fullName)
+	}
+}
+
+func TestExtractUser_FallbackToFirstUserShape(t *testing.T) {
+	values := map[string]interface{}{
+		"some-key": map[string]interface{}{"Login": "carol", "FullName": "Carol"},
+	}
+	login, _, fullName := extractUser(values)
+	if login != "carol" || fullName != "Carol" {
+		t.Errorf("fallback to first user-shape failed: login=%q fullName=%q", login, fullName)
+	}
+}
+
+func TestExtractUser_LowerCaseFieldNames(t *testing.T) {
+	// JSON-encoded sessions sometimes round-trip with lower-case
+	// field names. Helper accepts both.
+	values := map[string]interface{}{
+		"ssoUser": map[string]interface{}{
+			"login":    "dan",
+			"claims":   map[string]interface{}{"sub": "dan"},
+			"fullName": "Dan",
+		},
+	}
+	login, claims, fullName := extractUser(values)
+	if login != "dan" || fullName != "Dan" || claims["sub"] != "dan" {
+		t.Errorf("lower-case fallback failed: login=%q fullName=%q claims=%v", login, fullName, claims)
+	}
+}
+
+func TestExtractUser_NilOrEmpty(t *testing.T) {
+	if l, c, f := extractUser(nil); l != "" || c != nil || f != "" {
+		t.Errorf("nil values should yield zeros, got %q/%v/%q", l, c, f)
+	}
+	if l, c, f := extractUser(map[string]interface{}{}); l != "" || c != nil || f != "" {
+		t.Errorf("empty values should yield zeros, got %q/%v/%q", l, c, f)
+	}
+}
+
+func TestExtractUser_UnrelatedShapeIgnored(t *testing.T) {
+	// A value that's not a map[string]interface{} or doesn't have
+	// Login/login is ignored (no panic, no false match).
+	values := map[string]interface{}{
+		"a": "not-a-map",
+		"b": 42,
+	}
+	if l, _, _ := extractUser(values); l != "" {
+		t.Errorf("non-user-shape values should yield empty login, got %q", l)
+	}
+}
+
+// encodeName -------------------------------------------------------------
+
+func TestEncodeName_DeterministicAndPrefixed(t *testing.T) {
+	a := encodeName("tok-abc")
+	b := encodeName("tok-abc")
+	if a != b {
+		t.Errorf("encodeName not deterministic: %q vs %q", a, b)
+	}
+	if !strings.HasPrefix(a, "h-") {
+		t.Errorf("expected 'h-' prefix, got %q", a)
+	}
+	// SHA-256 hex = 64 chars; full name = 2 + 64 = 66.
+	if len(a) != 66 {
+		t.Errorf("expected length 66 (h- + 64 hex), got %d", len(a))
+	}
+}
+
+func TestEncodeName_DifferentTokensYieldDifferentNames(t *testing.T) {
+	if encodeName("a") == encodeName("b") {
+		t.Error("different tokens should yield different names")
+	}
+}
+
+func TestEncodeName_ProducesRFC1123CompliantName(t *testing.T) {
+	// h- prefix + lowercase hex → all chars are RFC1123-compliant
+	// (alphanumeric + -). Verify on a sample.
+	got := encodeName("token-with-special!@#$%^&*()_+chars")
+	for _, c := range got {
+		if !((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '-') {
+			t.Errorf("non-RFC1123 char in encoded name: %q", c)
+		}
+	}
+}

--- a/cmd/oidc/sessionstore/kubessostore_test.go
+++ b/cmd/oidc/sessionstore/kubessostore_test.go
@@ -144,6 +144,36 @@ func TestCommitCtx_UpdatesExisting(t *testing.T) {
 	}
 }
 
+func TestFind_NoLoggerInContextDoesNotPanic(t *testing.T) {
+	// Find() forwards to FindCtx with a bare context.Background() that carries no
+	// logger; the store must fall back to slog.Default() instead of panicking.
+	store, _ := newStore(t)
+	b, found, err := store.Find("missing-token")
+	if err != nil {
+		t.Fatalf("Find: %v", err)
+	}
+	if found || b != nil {
+		t.Fatalf("expected not-found, got found=%v len=%d", found, len(b))
+	}
+}
+
+func TestCommitCtx_NoErrorLoggedOnSuccessfulUpdate(t *testing.T) {
+	store, _ := newStore(t)
+	if err := store.CommitCtx(testCtx(), "tok-log", envelopeBytes(t, "alice", nil, "Alice"), time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("create commit: %v", err)
+	}
+	// Capture error-level logs during a successful update; none should appear.
+	var buf strings.Builder
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelError}))
+	ctx := logr.NewContextWithSlogLogger(context.Background(), logger)
+	if err := store.CommitCtx(ctx, "tok-log", envelopeBytes(t, "alice", nil, "Alice Updated"), time.Now().Add(2*time.Hour)); err != nil {
+		t.Fatalf("update commit: %v", err)
+	}
+	if strings.Contains(buf.String(), "Failed to update SSO session") {
+		t.Fatalf("error logged on a successful update:\n%s", buf.String())
+	}
+}
+
 func TestCommitCtx_InvalidJSONErrors(t *testing.T) {
 	store, _ := newStore(t)
 	if err := store.CommitCtx(testCtx(), "tok-bad", []byte("{not json"), time.Now()); err == nil {

--- a/cmd/oidc/sessionstore/kubessostore_test.go
+++ b/cmd/oidc/sessionstore/kubessostore_test.go
@@ -404,7 +404,8 @@ func TestEncodeName_ProducesRFC1123CompliantName(t *testing.T) {
 	// (alphanumeric + -). Verify on a sample.
 	got := encodeName("token-with-special!@#$%^&*()_+chars")
 	for _, c := range got {
-		if !((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '-') {
+		allowed := (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '-'
+		if !allowed {
 			t.Errorf("non-RFC1123 char in encoded name: %q", c)
 		}
 	}

--- a/cmd/oidc/sessionstore/kubessostore_test.go
+++ b/cmd/oidc/sessionstore/kubessostore_test.go
@@ -27,10 +27,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-// testCtx returns a context wired with a discard slog logger — required
-// by KubeSsoStore methods, which call `logr.FromContextAsSlogLogger(ctx)`
-// and panic on nil. Replaces plain `context.Background()` everywhere
-// in this file.
+// testCtx returns a context wired with a discard slog logger. KubeSsoStore
+// methods fall back to slog.Default() when the context carries no logger
+// (see loggerFrom), so this keeps test output quiet rather than guarding
+// against a panic. Replaces plain context.Background() throughout this file.
 func testCtx() context.Context {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	return logr.NewContextWithSlogLogger(context.Background(), logger)

--- a/cmd/oidc/upstreams/upstream_federation_test.go
+++ b/cmd/oidc/upstreams/upstream_federation_test.go
@@ -1,0 +1,751 @@
+/*
+Copyright (c) 2025 Kubotal.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package upstreams
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	kubauthv1alpha1 "kubauth/api/kubauth/v1alpha1"
+
+	"github.com/coreos/go-oidc/v3/oidc"
+	jose "github.com/go-jose/go-jose/v4"
+	"golang.org/x/oauth2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ---------------------------------------------------------------------------
+// Fake upstream IdP: serves discovery, JWKS, and userinfo over httptest so the
+// real go-oidc provider/verifier exercises the federation flow end to end.
+// ---------------------------------------------------------------------------
+
+const testKeyID = "test-key-1"
+
+// fakeIdP is an in-memory upstream OIDC provider backed by httptest.
+type fakeIdP struct {
+	t      *testing.T
+	server *httptest.Server
+	signer jose.Signer
+	pubJWK jose.JSONWebKey
+
+	// Tunable behaviour for negative tests. Guarded by nothing: the test sets
+	// these before issuing the request that reaches the relevant handler.
+	signingAlgs       []string // advertised id_token_signing_alg_values_supported
+	omitUserInfoURL   bool     // discovery doc has no userinfo_endpoint
+	userInfoStatus    int      // status returned by the userinfo endpoint (0 => 200)
+	userInfoBody      string   // raw body returned by the userinfo endpoint
+	userInfoCalls     int      // number of times userinfo was hit
+	lastUserInfoAuth  string   // Authorization header seen by userinfo
+	jwksStatus        int      // status returned by the jwks endpoint (0 => 200)
+	discoveryStatus   int      // status returned by discovery (0 => 200)
+	discoveryRawBody  string   // if set, returned verbatim by discovery
+	overrideIssuer    string   // if set, used as the discovery "issuer" value
+	codeChallengeMeth []string // advertised code_challenge_methods_supported
+}
+
+func newFakeIdP(t *testing.T) *fakeIdP {
+	t.Helper()
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa.GenerateKey: %v", err)
+	}
+	signer, err := jose.NewSigner(
+		jose.SigningKey{Algorithm: jose.RS256, Key: priv},
+		(&jose.SignerOptions{}).WithType("JWT").WithHeader("kid", testKeyID),
+	)
+	if err != nil {
+		t.Fatalf("jose.NewSigner: %v", err)
+	}
+	f := &fakeIdP{
+		t:           t,
+		signer:      signer,
+		signingAlgs: []string{"RS256"},
+		pubJWK: jose.JSONWebKey{
+			Key:       priv.Public(),
+			KeyID:     testKeyID,
+			Algorithm: "RS256",
+			Use:       "sig",
+		},
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/openid-configuration", f.handleDiscovery)
+	mux.HandleFunc("/jwks", f.handleJWKS)
+	mux.HandleFunc("/userinfo", f.handleUserInfo)
+	f.server = httptest.NewServer(mux)
+	t.Cleanup(f.server.Close)
+	return f
+}
+
+func (f *fakeIdP) issuer() string {
+	if f.overrideIssuer != "" {
+		return f.overrideIssuer
+	}
+	return f.server.URL
+}
+
+func (f *fakeIdP) handleDiscovery(w http.ResponseWriter, _ *http.Request) {
+	if f.discoveryStatus != 0 {
+		w.WriteHeader(f.discoveryStatus)
+		return
+	}
+	if f.discoveryRawBody != "" {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(f.discoveryRawBody))
+		return
+	}
+	doc := map[string]interface{}{
+		"issuer":                                f.issuer(),
+		"authorization_endpoint":                f.server.URL + "/auth",
+		"token_endpoint":                        f.server.URL + "/token",
+		"jwks_uri":                              f.server.URL + "/jwks",
+		"id_token_signing_alg_values_supported": f.signingAlgs,
+	}
+	if !f.omitUserInfoURL {
+		doc["userinfo_endpoint"] = f.server.URL + "/userinfo"
+	}
+	if len(f.codeChallengeMeth) > 0 {
+		doc["code_challenge_methods_supported"] = f.codeChallengeMeth
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(doc); err != nil {
+		f.t.Errorf("encode discovery: %v", err)
+	}
+}
+
+func (f *fakeIdP) handleJWKS(w http.ResponseWriter, _ *http.Request) {
+	if f.jwksStatus != 0 {
+		w.WriteHeader(f.jwksStatus)
+		return
+	}
+	set := jose.JSONWebKeySet{Keys: []jose.JSONWebKey{f.pubJWK}}
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(set); err != nil {
+		f.t.Errorf("encode jwks: %v", err)
+	}
+}
+
+func (f *fakeIdP) handleUserInfo(w http.ResponseWriter, r *http.Request) {
+	f.userInfoCalls++
+	f.lastUserInfoAuth = r.Header.Get("Authorization")
+	if f.userInfoStatus != 0 {
+		w.WriteHeader(f.userInfoStatus)
+		if f.userInfoBody != "" {
+			_, _ = w.Write([]byte(f.userInfoBody))
+		}
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if f.userInfoBody != "" {
+		_, _ = w.Write([]byte(f.userInfoBody))
+		return
+	}
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"sub":   "user-1",
+		"email": "user@example.com",
+		"name":  "User One",
+	})
+}
+
+// signIDToken signs the given claim set as a compact JWS (a JWT) with the IdP key.
+func (f *fakeIdP) signIDToken(t *testing.T, claims map[string]interface{}) string {
+	t.Helper()
+	payload, err := json.Marshal(claims)
+	if err != nil {
+		t.Fatalf("marshal claims: %v", err)
+	}
+	jws, err := f.signer.Sign(payload)
+	if err != nil {
+		t.Fatalf("sign id token: %v", err)
+	}
+	compact, err := jws.CompactSerialize()
+	if err != nil {
+		t.Fatalf("serialize id token: %v", err)
+	}
+	return compact
+}
+
+// standardClaims returns a valid-by-default ID token claim set for the given IdP/client.
+func (f *fakeIdP) standardClaims(clientID string) map[string]interface{} {
+	return map[string]interface{}{
+		"iss":   f.issuer(),
+		"sub":   "user-1",
+		"aud":   clientID,
+		"exp":   time.Now().Add(time.Hour).Unix(),
+		"iat":   time.Now().Add(-time.Minute).Unix(),
+		"email": "user@example.com",
+		"name":  "User One",
+	}
+}
+
+// newOIDCUpstream builds a real *upstream via NewUpstream pointed at the fake IdP
+// (discovery path). mutate may tweak the spec before construction.
+func (f *fakeIdP) newOIDCUpstream(t *testing.T, clientID, clientSecret string, mutate func(*kubauthv1alpha1.UpstreamProviderSpec)) Upstream {
+	t.Helper()
+	spec := kubauthv1alpha1.UpstreamProviderSpec{
+		Type:      kubauthv1alpha1.UpstreamProviderTypeOidc,
+		IssuerURL: f.server.URL,
+		ClientId:  clientID,
+		Scopes:    []string{"openid", "email"},
+	}
+	if mutate != nil {
+		mutate(&spec)
+	}
+	up := &kubauthv1alpha1.UpstreamProvider{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-upstream"},
+		Spec:       spec,
+	}
+	u, err := NewUpstream(context.Background(), up, clientSecret, nil)
+	if err != nil {
+		t.Fatalf("NewUpstream: %v", err)
+	}
+	return u
+}
+
+// ---------------------------------------------------------------------------
+// NewUpstream / NewInternalUpstream construction
+// ---------------------------------------------------------------------------
+
+func TestNewInternalUpstream_basics(t *testing.T) {
+	u := NewInternalUpstream("Local login")
+	if u.GetName() != "internal" {
+		t.Errorf("GetName = %q, want internal", u.GetName())
+	}
+	if u.GetDisplayName() != "Local login" {
+		t.Errorf("GetDisplayName = %q, want Local login", u.GetDisplayName())
+	}
+	if u.GetProviderType() != kubauthv1alpha1.UpstreamProviderTypeInternal {
+		t.Errorf("GetProviderType = %q, want internal", u.GetProviderType())
+	}
+	// Internal upstream has no OIDC provider: auth-code settings unavailable.
+	if settings, ok := u.OAuth2AuthCodeSettings(); ok || settings != nil {
+		t.Errorf("OAuth2AuthCodeSettings = (%v, %v), want (nil, false)", settings, ok)
+	}
+	if cfg := u.GetEffectiveConfig(); cfg != nil {
+		t.Errorf("GetEffectiveConfig = %v, want nil for internal", cfg)
+	}
+	// ClientContext on an upstream with no http client returns ctx unchanged.
+	ctx := context.Background()
+	if got := u.ClientContext(ctx); got != ctx {
+		t.Errorf("ClientContext returned a different context for internal upstream")
+	}
+	// ParseAndVerifyIDToken must fail clearly when there is no provider.
+	if _, err := u.ParseAndVerifyIDToken(ctx, "whatever"); err == nil {
+		t.Errorf("ParseAndVerifyIDToken on internal upstream: want error, got nil")
+	}
+	// FetchUserInfoClaims returns (nil, nil) when there is no provider.
+	claims, err := u.FetchUserInfoClaims(ctx, oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "x"}))
+	if err != nil {
+		t.Errorf("FetchUserInfoClaims on internal upstream: unexpected error %v", err)
+	}
+	if claims != nil {
+		t.Errorf("FetchUserInfoClaims on internal upstream: want nil, got %v", claims)
+	}
+}
+
+func TestNewUpstream_internalTypeSkipsDiscovery(t *testing.T) {
+	// An internal-typed UpstreamProvider must not attempt any HTTP discovery,
+	// even with a bogus issuer URL: NewUpstream short-circuits on the type.
+	up := &kubauthv1alpha1.UpstreamProvider{
+		ObjectMeta: metav1.ObjectMeta{Name: "int"},
+		Spec: kubauthv1alpha1.UpstreamProviderSpec{
+			Type:        kubauthv1alpha1.UpstreamProviderTypeInternal,
+			DisplayName: "Internal",
+			IssuerURL:   "http://127.0.0.1:1/does-not-exist",
+		},
+	}
+	u, err := NewUpstream(context.Background(), up, "", nil)
+	if err != nil {
+		t.Fatalf("NewUpstream(internal): unexpected error %v", err)
+	}
+	if u.GetProviderType() != kubauthv1alpha1.UpstreamProviderTypeInternal {
+		t.Errorf("type = %q, want internal", u.GetProviderType())
+	}
+	if _, ok := u.OAuth2AuthCodeSettings(); ok {
+		t.Errorf("internal upstream should not expose OAuth2AuthCodeSettings")
+	}
+}
+
+func TestNewUpstream_discoverySuccess(t *testing.T) {
+	f := newFakeIdP(t)
+	f.codeChallengeMeth = []string{"S256", "plain"}
+	u := f.newOIDCUpstream(t, "client-abc", "secret-xyz", nil)
+
+	if u.GetProviderType() != kubauthv1alpha1.UpstreamProviderTypeOidc {
+		t.Errorf("type = %q, want oidc", u.GetProviderType())
+	}
+	settings, ok := u.OAuth2AuthCodeSettings()
+	if !ok {
+		t.Fatalf("OAuth2AuthCodeSettings ok = false, want true after discovery")
+	}
+	if settings.ClientID != "client-abc" {
+		t.Errorf("ClientID = %q, want client-abc", settings.ClientID)
+	}
+	if settings.ClientSecret != "secret-xyz" {
+		t.Errorf("ClientSecret = %q, want secret-xyz", settings.ClientSecret)
+	}
+	if settings.Endpoint.AuthURL != f.server.URL+"/auth" {
+		t.Errorf("AuthURL = %q, want %q", settings.Endpoint.AuthURL, f.server.URL+"/auth")
+	}
+	if settings.Endpoint.TokenURL != f.server.URL+"/token" {
+		t.Errorf("TokenURL = %q, want %q", settings.Endpoint.TokenURL, f.server.URL+"/token")
+	}
+	if !settings.SupportsPKCES256 {
+		t.Errorf("SupportsPKCES256 = false, want true (S256 advertised)")
+	}
+	if strings.Join(settings.Scopes, ",") != "openid,email" {
+		t.Errorf("Scopes = %v, want [openid email]", settings.Scopes)
+	}
+
+	// EffectiveConfig is populated from discovery for the controller status.
+	cfg := u.GetEffectiveConfig()
+	if cfg == nil {
+		t.Fatalf("GetEffectiveConfig = nil after discovery, want populated")
+	}
+	if cfg.UserInfoURL != f.server.URL+"/userinfo" {
+		t.Errorf("EffectiveConfig.UserInfoURL = %q, want %q", cfg.UserInfoURL, f.server.URL+"/userinfo")
+	}
+	if cfg.JWKSURL != f.server.URL+"/jwks" {
+		t.Errorf("EffectiveConfig.JWKSURL = %q, want %q", cfg.JWKSURL, f.server.URL+"/jwks")
+	}
+	if strings.Join(cfg.Algorithms, ",") != "RS256" {
+		t.Errorf("EffectiveConfig.Algorithms = %v, want [RS256]", cfg.Algorithms)
+	}
+}
+
+func TestNewUpstream_discoveryIssuerMismatch(t *testing.T) {
+	f := newFakeIdP(t)
+	// Discovery doc advertises an issuer that does not match the requested one:
+	// go-oidc must reject this (mis-configuration / token-substitution guard).
+	f.overrideIssuer = "https://evil.example.com"
+	up := &kubauthv1alpha1.UpstreamProvider{
+		ObjectMeta: metav1.ObjectMeta{Name: "mismatch"},
+		Spec: kubauthv1alpha1.UpstreamProviderSpec{
+			Type:      kubauthv1alpha1.UpstreamProviderTypeOidc,
+			IssuerURL: f.server.URL,
+			ClientId:  "c",
+		},
+	}
+	_, err := NewUpstream(context.Background(), up, "", nil)
+	if err == nil {
+		t.Fatalf("NewUpstream: want issuer-mismatch error, got nil")
+	}
+	if !strings.Contains(err.Error(), "oidc provider") {
+		t.Errorf("error = %v, want it wrapped as 'oidc provider' failure", err)
+	}
+}
+
+func TestNewUpstream_discoveryHTTPError(t *testing.T) {
+	f := newFakeIdP(t)
+	f.discoveryStatus = http.StatusInternalServerError
+	up := &kubauthv1alpha1.UpstreamProvider{
+		ObjectMeta: metav1.ObjectMeta{Name: "boom"},
+		Spec: kubauthv1alpha1.UpstreamProviderSpec{
+			Type:      kubauthv1alpha1.UpstreamProviderTypeOidc,
+			IssuerURL: f.server.URL,
+			ClientId:  "c",
+		},
+	}
+	_, err := NewUpstream(context.Background(), up, "", nil)
+	if err == nil {
+		t.Fatalf("NewUpstream: want error on discovery 500, got nil")
+	}
+}
+
+func TestNewUpstream_invalidIssuerURLScheme(t *testing.T) {
+	// httpclient.New rejects non-http(s) schemes before any network call.
+	up := &kubauthv1alpha1.UpstreamProvider{
+		ObjectMeta: metav1.ObjectMeta{Name: "bad-scheme"},
+		Spec: kubauthv1alpha1.UpstreamProviderSpec{
+			Type:      kubauthv1alpha1.UpstreamProviderTypeOidc,
+			IssuerURL: "ftp://example.com",
+			ClientId:  "c",
+		},
+	}
+	_, err := NewUpstream(context.Background(), up, "", nil)
+	if err == nil {
+		t.Fatalf("NewUpstream: want error for ftp:// issuer, got nil")
+	}
+	if !strings.Contains(err.Error(), "http client") {
+		t.Errorf("error = %v, want it wrapped as 'http client' failure", err)
+	}
+}
+
+func TestNewUpstream_explicitConfigSkipsDiscovery(t *testing.T) {
+	f := newFakeIdP(t)
+	// With ExplicitConfig set, NewUpstream must NOT call discovery. Point the
+	// well-known handler at a 500 so any discovery attempt would fail the test.
+	f.discoveryStatus = http.StatusInternalServerError
+	explicit := &kubauthv1alpha1.UpstreamProviderConfig{
+		AuthURL:          f.server.URL + "/auth",
+		TokenURL:         f.server.URL + "/token",
+		UserInfoURL:      f.server.URL + "/userinfo",
+		JWKSURL:          f.server.URL + "/jwks",
+		Algorithms:       []string{"RS256"},
+		IntrospectionURL: f.server.URL + "/introspect",
+		EndSessionURL:    f.server.URL + "/logout",
+	}
+	u := f.newOIDCUpstream(t, "client-1", "sec", func(s *kubauthv1alpha1.UpstreamProviderSpec) {
+		s.ExplicitConfig = explicit
+	})
+
+	settings, ok := u.OAuth2AuthCodeSettings()
+	if !ok {
+		t.Fatalf("OAuth2AuthCodeSettings ok = false, want true with explicit config")
+	}
+	if settings.Endpoint.TokenURL != f.server.URL+"/token" {
+		t.Errorf("TokenURL = %q, want %q", settings.Endpoint.TokenURL, f.server.URL+"/token")
+	}
+	cfg := u.GetEffectiveConfig()
+	if cfg == nil {
+		t.Fatalf("GetEffectiveConfig = nil, want populated from explicit config")
+	}
+	if cfg.IntrospectionURL != f.server.URL+"/introspect" {
+		t.Errorf("IntrospectionURL = %q, want %q", cfg.IntrospectionURL, f.server.URL+"/introspect")
+	}
+	if cfg.EndSessionURL != f.server.URL+"/logout" {
+		t.Errorf("EndSessionURL = %q, want %q", cfg.EndSessionURL, f.server.URL+"/logout")
+	}
+	// Explicit config did not advertise S256 PKCE.
+	if settings.SupportsPKCES256 {
+		t.Errorf("SupportsPKCES256 = true, want false (no code_challenge_methods in explicit config)")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ParseAndVerifyIDToken: the core federation token-verification path
+// ---------------------------------------------------------------------------
+
+func TestParseAndVerifyIDToken_success(t *testing.T) {
+	f := newFakeIdP(t)
+	u := f.newOIDCUpstream(t, "client-abc", "", nil)
+
+	claims := f.standardClaims("client-abc")
+	claims["groups"] = []interface{}{"admins", "dev"}
+	raw := f.signIDToken(t, claims)
+
+	got, err := u.ParseAndVerifyIDToken(context.Background(), raw)
+	if err != nil {
+		t.Fatalf("ParseAndVerifyIDToken: unexpected error %v", err)
+	}
+	if got["sub"] != "user-1" {
+		t.Errorf("sub = %v, want user-1", got["sub"])
+	}
+	if got["email"] != "user@example.com" {
+		t.Errorf("email = %v, want user@example.com", got["email"])
+	}
+	groups, ok := got["groups"].([]interface{})
+	if !ok || len(groups) != 2 || groups[0] != "admins" {
+		t.Errorf("groups = %v, want [admins dev]", got["groups"])
+	}
+	// Registered claims survive verification (cleanup is a separate step).
+	if got["iss"] != f.server.URL {
+		t.Errorf("iss = %v, want %v", got["iss"], f.server.URL)
+	}
+}
+
+func TestParseAndVerifyIDToken_audienceMismatch(t *testing.T) {
+	f := newFakeIdP(t)
+	u := f.newOIDCUpstream(t, "client-abc", "", nil)
+
+	// Token issued for a different audience than the configured clientId.
+	claims := f.standardClaims("some-other-client")
+	raw := f.signIDToken(t, claims)
+
+	_, err := u.ParseAndVerifyIDToken(context.Background(), raw)
+	if err == nil {
+		t.Fatalf("ParseAndVerifyIDToken: want audience-mismatch error, got nil")
+	}
+	if !strings.Contains(err.Error(), "audience") {
+		t.Errorf("error = %v, want audience mismatch", err)
+	}
+}
+
+func TestParseAndVerifyIDToken_expired(t *testing.T) {
+	f := newFakeIdP(t)
+	u := f.newOIDCUpstream(t, "client-abc", "", nil)
+
+	claims := f.standardClaims("client-abc")
+	claims["exp"] = time.Now().Add(-time.Hour).Unix()
+	raw := f.signIDToken(t, claims)
+
+	_, err := u.ParseAndVerifyIDToken(context.Background(), raw)
+	if err == nil {
+		t.Fatalf("ParseAndVerifyIDToken: want expiry error, got nil")
+	}
+	var expErr *oidc.TokenExpiredError
+	if !errors.As(err, &expErr) {
+		t.Errorf("error = %v, want *oidc.TokenExpiredError", err)
+	}
+}
+
+func TestParseAndVerifyIDToken_issuerMismatch(t *testing.T) {
+	f := newFakeIdP(t)
+	u := f.newOIDCUpstream(t, "client-abc", "", nil)
+
+	claims := f.standardClaims("client-abc")
+	claims["iss"] = "https://attacker.example.com"
+	raw := f.signIDToken(t, claims)
+
+	_, err := u.ParseAndVerifyIDToken(context.Background(), raw)
+	if err == nil {
+		t.Fatalf("ParseAndVerifyIDToken: want issuer-mismatch error, got nil")
+	}
+	if !strings.Contains(err.Error(), "different provider") {
+		t.Errorf("error = %v, want issuer mismatch ('different provider')", err)
+	}
+}
+
+func TestParseAndVerifyIDToken_badSignature(t *testing.T) {
+	f := newFakeIdP(t)
+	u := f.newOIDCUpstream(t, "client-abc", "", nil)
+
+	// Sign with a DIFFERENT key than the one published at the JWKS endpoint.
+	otherKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa.GenerateKey: %v", err)
+	}
+	otherSigner, err := jose.NewSigner(
+		jose.SigningKey{Algorithm: jose.RS256, Key: otherKey},
+		(&jose.SignerOptions{}).WithType("JWT").WithHeader("kid", testKeyID),
+	)
+	if err != nil {
+		t.Fatalf("jose.NewSigner: %v", err)
+	}
+	payload, err := json.Marshal(f.standardClaims("client-abc"))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	jws, err := otherSigner.Sign(payload)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	raw, err := jws.CompactSerialize()
+	if err != nil {
+		t.Fatalf("serialize: %v", err)
+	}
+
+	_, err = u.ParseAndVerifyIDToken(context.Background(), raw)
+	if err == nil {
+		t.Fatalf("ParseAndVerifyIDToken: want signature-verification error, got nil")
+	}
+	if !strings.Contains(err.Error(), "signature") {
+		t.Errorf("error = %v, want signature failure", err)
+	}
+}
+
+func TestParseAndVerifyIDToken_malformedToken(t *testing.T) {
+	f := newFakeIdP(t)
+	u := f.newOIDCUpstream(t, "client-abc", "", nil)
+
+	_, err := u.ParseAndVerifyIDToken(context.Background(), "not-a-jwt")
+	if err == nil {
+		t.Fatalf("ParseAndVerifyIDToken: want malformed-jwt error, got nil")
+	}
+	if !strings.Contains(err.Error(), "malformed") {
+		t.Errorf("error = %v, want malformed jwt", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// FetchUserInfoClaims: the userinfo leg of federation
+// ---------------------------------------------------------------------------
+
+func TestFetchUserInfoClaims_success(t *testing.T) {
+	f := newFakeIdP(t)
+	f.userInfoBody = `{"sub":"user-1","email":"user@example.com","name":"User One","department":"eng"}`
+	u := f.newOIDCUpstream(t, "client-abc", "", nil)
+
+	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "access-token-123", TokenType: "Bearer"})
+	claims, err := u.FetchUserInfoClaims(context.Background(), ts)
+	if err != nil {
+		t.Fatalf("FetchUserInfoClaims: unexpected error %v", err)
+	}
+	if claims["sub"] != "user-1" {
+		t.Errorf("sub = %v, want user-1", claims["sub"])
+	}
+	if claims["department"] != "eng" {
+		t.Errorf("department = %v, want eng", claims["department"])
+	}
+	if f.userInfoCalls != 1 {
+		t.Errorf("userInfoCalls = %d, want 1", f.userInfoCalls)
+	}
+	// The access token must be forwarded as a Bearer credential to the IdP.
+	if f.lastUserInfoAuth != "Bearer access-token-123" {
+		t.Errorf("userinfo Authorization = %q, want %q", f.lastUserInfoAuth, "Bearer access-token-123")
+	}
+}
+
+func TestFetchUserInfoClaims_noUserInfoEndpoint(t *testing.T) {
+	f := newFakeIdP(t)
+	f.omitUserInfoURL = true // discovery doc has no userinfo_endpoint
+	u := f.newOIDCUpstream(t, "client-abc", "", nil)
+
+	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "tok"})
+	claims, err := u.FetchUserInfoClaims(context.Background(), ts)
+	if err != nil {
+		t.Fatalf("FetchUserInfoClaims: unexpected error %v", err)
+	}
+	if claims != nil {
+		t.Errorf("claims = %v, want nil when no userinfo endpoint", claims)
+	}
+	if f.userInfoCalls != 0 {
+		t.Errorf("userInfoCalls = %d, want 0 (endpoint absent)", f.userInfoCalls)
+	}
+}
+
+func TestFetchUserInfoClaims_httpError(t *testing.T) {
+	f := newFakeIdP(t)
+	f.userInfoStatus = http.StatusUnauthorized
+	f.userInfoBody = "nope"
+	u := f.newOIDCUpstream(t, "client-abc", "", nil)
+
+	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "tok"})
+	_, err := u.FetchUserInfoClaims(context.Background(), ts)
+	if err == nil {
+		t.Fatalf("FetchUserInfoClaims: want error on 401, got nil")
+	}
+}
+
+func TestFetchUserInfoClaims_malformedJSON(t *testing.T) {
+	f := newFakeIdP(t)
+	f.userInfoBody = "{not json"
+	u := f.newOIDCUpstream(t, "client-abc", "", nil)
+
+	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "tok"})
+	_, err := u.FetchUserInfoClaims(context.Background(), ts)
+	if err == nil {
+		t.Fatalf("FetchUserInfoClaims: want decode error on bad JSON, got nil")
+	}
+}
+
+func TestFetchUserInfoClaims_tokenSourceError(t *testing.T) {
+	f := newFakeIdP(t)
+	u := f.newOIDCUpstream(t, "client-abc", "", nil)
+
+	_, err := u.FetchUserInfoClaims(context.Background(), errTokenSource{})
+	if err == nil {
+		t.Fatalf("FetchUserInfoClaims: want error when token source fails, got nil")
+	}
+	if f.userInfoCalls != 0 {
+		t.Errorf("userInfoCalls = %d, want 0 (token never obtained)", f.userInfoCalls)
+	}
+}
+
+// errTokenSource always fails to mint a token, exercising the token-source error path.
+type errTokenSource struct{}
+
+func (errTokenSource) Token() (*oauth2.Token, error) {
+	return nil, errors.New("token source boom")
+}
+
+// ---------------------------------------------------------------------------
+// End-to-end federation: verify ID token, fetch userinfo, then apply the
+// claim transformations (cleanup + renaming) as the federation pipeline does.
+// ---------------------------------------------------------------------------
+
+func TestFederationFlow_verifyFetchTransformMerge(t *testing.T) {
+	f := newFakeIdP(t)
+	f.userInfoBody = `{"sub":"user-1","department":"eng","email":"ui@example.com"}`
+	u := f.newOIDCUpstream(t, "client-abc", "", func(s *kubauthv1alpha1.UpstreamProviderSpec) {
+		s.UseUserInfo = true
+		// Rename upstream "name" claim to canonical "display_name", drop "email".
+		s.ClaimRenamings = []kubauthv1alpha1.ClaimRenamingSpec{
+			{OldName: "name", NewName: "display_name", Operation: kubauthv1alpha1.RenamingOperationRename},
+		}
+		s.ClaimRemovals = []string{"email"}
+	})
+
+	if !u.UseUserInfo() {
+		t.Fatalf("UseUserInfo = false, want true")
+	}
+
+	// 1) Verify the ID token.
+	idClaims := f.standardClaims("client-abc")
+	idClaims["name"] = "User One"
+	raw := f.signIDToken(t, idClaims)
+	verified, err := u.ParseAndVerifyIDToken(context.Background(), raw)
+	if err != nil {
+		t.Fatalf("ParseAndVerifyIDToken: %v", err)
+	}
+
+	// 2) Fetch userinfo and merge into the claim set (userinfo wins on conflict,
+	//    matching the federation merge order: id token first, userinfo overlaid).
+	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "tok", TokenType: "Bearer"})
+	uiClaims, err := u.FetchUserInfoClaims(context.Background(), ts)
+	if err != nil {
+		t.Fatalf("FetchUserInfoClaims: %v", err)
+	}
+	merged := cloneClaimSet(verified)
+	for k, v := range uiClaims {
+		merged[k] = v
+	}
+	if merged["department"] != "eng" {
+		t.Errorf("merged department = %v, want eng (from userinfo)", merged["department"])
+	}
+
+	// 3) Cleanup registered/removed claims, then rename.
+	cleaned := u.CleanupClaims(merged)
+	if _, ok := cleaned["iss"]; ok {
+		t.Errorf("cleaned still has iss; CleanupClaims must drop registered claims")
+	}
+	if _, ok := cleaned["email"]; ok {
+		t.Errorf("cleaned still has email; ClaimRemovals must drop it")
+	}
+	if cleaned["sub"] != "user-1" {
+		t.Errorf("cleaned sub = %v, want user-1 (sub must survive cleanup)", cleaned["sub"])
+	}
+
+	final := u.PerformRenaming(cleaned)
+	if final["display_name"] != "User One" {
+		t.Errorf("final display_name = %v, want User One (renamed from name)", final["display_name"])
+	}
+	if _, ok := final["name"]; ok {
+		t.Errorf("final still has name; rename must move it to display_name")
+	}
+	if final["department"] != "eng" {
+		t.Errorf("final department = %v, want eng (preserved through transforms)", final["department"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ClientContext wires the upstream's TLS-aware http client into the ctx so the
+// oidc library uses it. We assert the value actually changes for an OIDC upstream.
+// ---------------------------------------------------------------------------
+
+func TestClientContext_wrapsHTTPClientForOIDC(t *testing.T) {
+	f := newFakeIdP(t)
+	u := f.newOIDCUpstream(t, "client-abc", "", nil)
+
+	ctx := context.Background()
+	wrapped := u.ClientContext(ctx)
+	if wrapped == ctx {
+		t.Errorf("ClientContext returned the same context; expected the upstream http client to be injected")
+	}
+	// And the wrapped context must carry a usable client: a fresh provider built
+	// from it can complete discovery against the fake IdP over plain http.
+	if _, err := oidc.NewProvider(wrapped, f.server.URL); err != nil {
+		t.Errorf("oidc.NewProvider via ClientContext failed: %v", err)
+	}
+}

--- a/cmd/ucrd/authenticator/crdAuthenticator_test.go
+++ b/cmd/ucrd/authenticator/crdAuthenticator_test.go
@@ -1,0 +1,284 @@
+/*
+Copyright (c) 2025 Kubotal.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package authenticator
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	kubauthv1alpha1 "kubauth/api/kubauth/v1alpha1"
+	"kubauth/internal/proto"
+
+	"github.com/go-logr/logr"
+	"golang.org/x/crypto/bcrypt"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// helpers ----------------------------------------------------------------
+
+const userNS = "kubauth-users"
+
+// newAuthenticator returns a crdAuthenticator wired to a fake client
+// pre-loaded with the supplied seed and the same `userkey` field index
+// the production code (cmd/ucrd/ucrd.go) registers on the manager —
+// without it, `client.MatchingFields{"userkey": login}` returns nothing.
+func newAuthenticator(t *testing.T, seed ...client.Object) *crdAuthenticator {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := kubauthv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(seed...).
+		WithIndex(&kubauthv1alpha1.GroupBinding{}, "userkey", func(o client.Object) []string {
+			gb := o.(*kubauthv1alpha1.GroupBinding)
+			return []string{gb.Spec.User}
+		}).
+		Build()
+	return &crdAuthenticator{k8sClient: c, userNamespace: userNS}
+}
+
+func testCtx() context.Context {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	return logr.NewContextWithSlogLogger(context.Background(), logger)
+}
+
+func mustHash(t *testing.T, pw string) string {
+	t.Helper()
+	h, err := bcrypt.GenerateFromPassword([]byte(pw), bcrypt.MinCost)
+	if err != nil {
+		t.Fatalf("bcrypt: %v", err)
+	}
+	return string(h)
+}
+
+func userObj(login string, modify func(*kubauthv1alpha1.User)) *kubauthv1alpha1.User {
+	u := &kubauthv1alpha1.User{
+		ObjectMeta: metav1.ObjectMeta{Namespace: userNS, Name: login},
+		Spec:       kubauthv1alpha1.UserSpec{Name: login},
+	}
+	if modify != nil {
+		modify(u)
+	}
+	return u
+}
+
+func bindingObj(name, user, group string) *kubauthv1alpha1.GroupBinding {
+	return &kubauthv1alpha1.GroupBinding{
+		ObjectMeta: metav1.ObjectMeta{Namespace: userNS, Name: name},
+		Spec:       kubauthv1alpha1.GroupBindingSpec{User: user, Group: group},
+	}
+}
+
+func groupObj(name string, claimsJSON string) *kubauthv1alpha1.Group {
+	g := &kubauthv1alpha1.Group{
+		ObjectMeta: metav1.ObjectMeta{Namespace: userNS, Name: name},
+	}
+	if claimsJSON != "" {
+		g.Spec.Claims = &apiextensionsv1.JSON{Raw: []byte(claimsJSON)}
+	}
+	return g
+}
+
+// tests ------------------------------------------------------------------
+
+func TestAuthenticate_UserNotFound(t *testing.T) {
+	a := newAuthenticator(t)
+	resp, err := a.Authenticate(testCtx(), &proto.IdentityRequest{Login: "ghost"})
+	if err != nil {
+		t.Fatalf("Authenticate: %v", err)
+	}
+	if resp.Status != proto.UserNotFound {
+		t.Errorf("expected UserNotFound, got %v", resp.Status)
+	}
+	if resp.User.Login != "ghost" {
+		t.Errorf("response should echo login, got %q", resp.User.Login)
+	}
+}
+
+func TestAuthenticate_PasswordMissing(t *testing.T) {
+	// User exists but spec.passwordHash is empty — kubauth says
+	// PasswordMissing (provider has nothing to check against).
+	a := newAuthenticator(t, userObj("alice", nil))
+	resp, err := a.Authenticate(testCtx(), &proto.IdentityRequest{Login: "alice", Password: "anything"})
+	if err != nil {
+		t.Fatalf("Authenticate: %v", err)
+	}
+	if resp.Status != proto.PasswordMissing {
+		t.Errorf("expected PasswordMissing, got %v", resp.Status)
+	}
+}
+
+func TestAuthenticate_PasswordUnchecked(t *testing.T) {
+	// User has a hash, but request omits the password (e.g. an
+	// upstream OIDC trust scenario). Status = PasswordUnchecked.
+	a := newAuthenticator(t, userObj("alice", func(u *kubauthv1alpha1.User) {
+		u.Spec.PasswordHash = mustHash(t, "secret")
+	}))
+	resp, err := a.Authenticate(testCtx(), &proto.IdentityRequest{Login: "alice", Password: ""})
+	if err != nil {
+		t.Fatalf("Authenticate: %v", err)
+	}
+	if resp.Status != proto.PasswordUnchecked {
+		t.Errorf("expected PasswordUnchecked, got %v", resp.Status)
+	}
+}
+
+func TestAuthenticate_PasswordChecked(t *testing.T) {
+	a := newAuthenticator(t, userObj("alice", func(u *kubauthv1alpha1.User) {
+		u.Spec.PasswordHash = mustHash(t, "secret")
+	}))
+	resp, err := a.Authenticate(testCtx(), &proto.IdentityRequest{Login: "alice", Password: "secret"})
+	if err != nil {
+		t.Fatalf("Authenticate: %v", err)
+	}
+	if resp.Status != proto.PasswordChecked {
+		t.Errorf("expected PasswordChecked, got %v", resp.Status)
+	}
+}
+
+func TestAuthenticate_PasswordFail(t *testing.T) {
+	a := newAuthenticator(t, userObj("alice", func(u *kubauthv1alpha1.User) {
+		u.Spec.PasswordHash = mustHash(t, "secret")
+	}))
+	resp, err := a.Authenticate(testCtx(), &proto.IdentityRequest{Login: "alice", Password: "WRONG"})
+	if err != nil {
+		t.Fatalf("Authenticate: %v", err)
+	}
+	if resp.Status != proto.PasswordFail {
+		t.Errorf("expected PasswordFail, got %v", resp.Status)
+	}
+}
+
+func TestAuthenticate_DisabledUser(t *testing.T) {
+	// Disabled flag overrides any password check.
+	disabled := true
+	a := newAuthenticator(t, userObj("alice", func(u *kubauthv1alpha1.User) {
+		u.Spec.PasswordHash = mustHash(t, "secret")
+		u.Spec.Disabled = &disabled
+	}))
+	resp, err := a.Authenticate(testCtx(), &proto.IdentityRequest{Login: "alice", Password: "secret"})
+	if err != nil {
+		t.Fatalf("Authenticate: %v", err)
+	}
+	if resp.Status != proto.Disabled {
+		t.Errorf("expected Disabled, got %v", resp.Status)
+	}
+}
+
+func TestAuthenticate_PopulatesUidNameEmails(t *testing.T) {
+	uid := 1042
+	a := newAuthenticator(t, userObj("alice", func(u *kubauthv1alpha1.User) {
+		u.Spec.PasswordHash = mustHash(t, "secret")
+		u.Spec.Uid = &uid
+		u.Spec.Name = "Alice Wonderland"
+		u.Spec.Emails = []string{"alice@example.org", "alice@personal.com"}
+	}))
+	resp, err := a.Authenticate(testCtx(), &proto.IdentityRequest{Login: "alice", Password: "secret"})
+	if err != nil {
+		t.Fatalf("Authenticate: %v", err)
+	}
+	if resp.User.Name != "Alice Wonderland" {
+		t.Errorf("name not populated: %q", resp.User.Name)
+	}
+	if resp.User.Uid == nil || *resp.User.Uid != 1042 {
+		t.Errorf("uid not populated: %v", resp.User.Uid)
+	}
+	if len(resp.User.Emails) != 2 || resp.User.Emails[0] != "alice@example.org" {
+		t.Errorf("emails not populated: %v", resp.User.Emails)
+	}
+}
+
+func TestAuthenticate_GroupsFromBindings(t *testing.T) {
+	// Two GroupBindings for alice, alphabetically not sorted in the
+	// fixture. The code sorts by group name → response groups are sorted.
+	a := newAuthenticator(t,
+		userObj("alice", nil),
+		bindingObj("b1", "alice", "viewers"),
+		bindingObj("b2", "alice", "admins"),
+		// noise: a binding for someone else, must NOT appear in alice's response
+		bindingObj("b3", "bob", "admins"),
+	)
+	resp, err := a.Authenticate(testCtx(), &proto.IdentityRequest{Login: "alice"})
+	if err != nil {
+		t.Fatalf("Authenticate: %v", err)
+	}
+	if len(resp.User.Groups) != 2 {
+		t.Fatalf("expected 2 groups, got %v", resp.User.Groups)
+	}
+	if resp.User.Groups[0] != "admins" || resp.User.Groups[1] != "viewers" {
+		t.Errorf("groups not sorted: %v", resp.User.Groups)
+	}
+}
+
+func TestAuthenticate_GroupClaimsMergedUserClaimsWin(t *testing.T) {
+	// Group provides shared claims; User overrides shared keys.
+	// The contract: User.Claims take precedence on conflict.
+	a := newAuthenticator(t,
+		userObj("alice", func(u *kubauthv1alpha1.User) {
+			u.Spec.Claims = &apiextensionsv1.JSON{
+				Raw: []byte(`{"role":"user","extra":"u"}`),
+			}
+		}),
+		bindingObj("b", "alice", "admins"),
+		groupObj("admins", `{"role":"admin","org":"kubauth"}`),
+	)
+	resp, err := a.Authenticate(testCtx(), &proto.IdentityRequest{Login: "alice"})
+	if err != nil {
+		t.Fatalf("Authenticate: %v", err)
+	}
+	// User wins on `role`, group's `org` survives, User's `extra` survives.
+	if resp.User.Claims["role"] != "user" {
+		t.Errorf("user claim should override group: role=%v", resp.User.Claims["role"])
+	}
+	if resp.User.Claims["org"] != "kubauth" {
+		t.Errorf("group claim should survive: org=%v", resp.User.Claims["org"])
+	}
+	if resp.User.Claims["extra"] != "u" {
+		t.Errorf("user-only claim missing: %v", resp.User.Claims["extra"])
+	}
+}
+
+func TestAuthenticate_GroupBindingPointsToMissingGroupIsTolerated(t *testing.T) {
+	// A GroupBinding referencing a Group that doesn't exist must NOT
+	// fail authentication — the binding's group name still goes into
+	// the response, the missing group just contributes no claims.
+	a := newAuthenticator(t,
+		userObj("alice", nil),
+		bindingObj("b", "alice", "ghost-group"), // no Group "ghost-group" CR
+	)
+	resp, err := a.Authenticate(testCtx(), &proto.IdentityRequest{Login: "alice"})
+	if err != nil {
+		t.Fatalf("Authenticate: %v", err)
+	}
+	if len(resp.User.Groups) != 1 || resp.User.Groups[0] != "ghost-group" {
+		t.Errorf("group name should appear despite missing CR: %v", resp.User.Groups)
+	}
+}
+
+func TestAuthenticate_NoBindingsForUser(t *testing.T) {
+	// Other bindings exist but none for alice → empty groups.
+	a := newAuthenticator(t,
+		userObj("alice", nil),
+		bindingObj("b", "bob", "admins"),
+	)
+	resp, err := a.Authenticate(testCtx(), &proto.IdentityRequest{Login: "alice"})
+	if err != nil {
+		t.Fatalf("Authenticate: %v", err)
+	}
+	if len(resp.User.Groups) != 0 {
+		t.Errorf("alice should have no groups, got %v", resp.User.Groups)
+	}
+}

--- a/cmd/ucrd/authenticator/crdAuthenticator_test.go
+++ b/cmd/ucrd/authenticator/crdAuthenticator_test.go
@@ -9,6 +9,7 @@ package authenticator
 
 import (
 	"context"
+	"errors"
 	"io"
 	"log/slog"
 	"testing"
@@ -23,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
 // helpers ----------------------------------------------------------------
@@ -280,5 +282,60 @@ func TestAuthenticate_NoBindingsForUser(t *testing.T) {
 	}
 	if len(resp.User.Groups) != 0 {
 		t.Errorf("alice should have no groups, got %v", resp.User.Groups)
+	}
+}
+
+// fail-closed: API errors must DENY, never allow ------------------------
+
+// newFailingListAuthenticator wires a crdAuthenticator on top of a fake
+// client whose List always errors, simulating an apiserver outage / RBAC
+// rejection while resolving the user's GroupBindings.
+func newFailingListAuthenticator(t *testing.T, listErr error, seed ...client.Object) *crdAuthenticator {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := kubauthv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(seed...).
+		WithIndex(&kubauthv1alpha1.GroupBinding{}, "userkey", func(o client.Object) []string {
+			gb := o.(*kubauthv1alpha1.GroupBinding)
+			return []string{gb.Spec.User}
+		}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error {
+				return listErr
+			},
+		}).
+		Build()
+	return &crdAuthenticator{k8sClient: c, userNamespace: userNS}
+}
+
+func TestAuthenticate_ListErrorDeniesNotAllows(t *testing.T) {
+	// SECURITY (fail-closed): if the GroupBinding List fails, Authenticate
+	// must surface a non-nil error and NOT fabricate an allow-ish response.
+	// A swallowed List error could otherwise let a request through with
+	// empty groups / no claims, silently dropping authorization data.
+	sentinel := errors.New("apiserver unavailable")
+	// Seed a perfectly valid, password-checkable user. If the code ignored
+	// the List failure it would happily return PasswordChecked — exactly
+	// the dangerous outcome this test forbids.
+	a := newFailingListAuthenticator(t, sentinel,
+		userObj("alice", func(u *kubauthv1alpha1.User) {
+			u.Spec.PasswordHash = mustHash(t, "secret")
+		}),
+	)
+
+	resp, err := a.Authenticate(testCtx(), &proto.IdentityRequest{Login: "alice", Password: "secret"})
+
+	if err == nil {
+		t.Fatalf("expected a non-nil error on List failure (fail-closed), got resp=%+v", resp)
+	}
+	if !errors.Is(err, sentinel) {
+		t.Errorf("error should wrap the underlying List error, got %v", err)
+	}
+	if resp != nil {
+		t.Errorf("on deny the response must be nil, got %+v", resp)
 	}
 }

--- a/cmd/ucrd/authenticator/crdAuthenticator_test.go
+++ b/cmd/ucrd/authenticator/crdAuthenticator_test.go
@@ -339,3 +339,78 @@ func TestAuthenticate_ListErrorDeniesNotAllows(t *testing.T) {
 		t.Errorf("on deny the response must be nil, got %+v", resp)
 	}
 }
+
+// newFailingGetAuthenticator wires a crdAuthenticator whose Get always errors,
+// simulating an apiserver outage / RBAC rejection while fetching the User or a
+// bound Group. List still works, so the failure is isolated to Get.
+func newFailingGetAuthenticator(t *testing.T, getErr error, seed ...client.Object) *crdAuthenticator {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := kubauthv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(seed...).
+		WithIndex(&kubauthv1alpha1.GroupBinding{}, "userkey", func(o client.Object) []string {
+			return []string{o.(*kubauthv1alpha1.GroupBinding).Spec.User}
+		}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+				return getErr
+			},
+		}).
+		Build()
+	return &crdAuthenticator{k8sClient: c, userNamespace: userNS}
+}
+
+func TestAuthenticate_UserGetErrorDeniesNotAllows(t *testing.T) {
+	// SECURITY (fail-closed): a non-NotFound error while fetching the User must
+	// deny. With no GroupBindings seeded, the only Get is the User fetch, so this
+	// isolates the primary deny path: a valid, password-checkable user must NOT
+	// slip through (as UserNotFound or worse) when the apiserver errors.
+	sentinel := errors.New("apiserver unavailable")
+	a := newFailingGetAuthenticator(t, sentinel,
+		userObj("alice", func(u *kubauthv1alpha1.User) {
+			u.Spec.PasswordHash = mustHash(t, "secret")
+		}),
+	)
+
+	resp, err := a.Authenticate(testCtx(), &proto.IdentityRequest{Login: "alice", Password: "secret"})
+
+	if err == nil {
+		t.Fatalf("expected a non-nil error on User Get failure (fail-closed), got resp=%+v", resp)
+	}
+	if !errors.Is(err, sentinel) {
+		t.Errorf("error should wrap the underlying Get error, got %v", err)
+	}
+	if resp != nil {
+		t.Errorf("on deny the response must be nil, got %+v", resp)
+	}
+}
+
+func TestAuthenticate_GroupGetErrorDeniesNotAllows(t *testing.T) {
+	// SECURITY (fail-closed): a non-NotFound error while fetching a bound Group
+	// must deny, not silently drop the group's claims. (A NotFound is tolerated,
+	// covered by TestAuthenticate_GroupBindingPointsToMissingGroupIsTolerated.)
+	sentinel := errors.New("apiserver unavailable")
+	a := newFailingGetAuthenticator(t, sentinel,
+		userObj("alice", func(u *kubauthv1alpha1.User) {
+			u.Spec.PasswordHash = mustHash(t, "secret")
+		}),
+		bindingObj("b", "alice", "admins"),
+		groupObj("admins", `{"role":"admin"}`),
+	)
+
+	resp, err := a.Authenticate(testCtx(), &proto.IdentityRequest{Login: "alice", Password: "secret"})
+
+	if err == nil {
+		t.Fatalf("expected a non-nil error on Group Get failure (fail-closed), got resp=%+v", resp)
+	}
+	if !errors.Is(err, sentinel) {
+		t.Errorf("error should wrap the underlying Get error, got %v", err)
+	}
+	if resp != nil {
+		t.Errorf("on deny the response must be nil, got %+v", resp)
+	}
+}

--- a/internal/handlers/protector/bfa_test.go
+++ b/internal/handlers/protector/bfa_test.go
@@ -1,0 +1,329 @@
+/*
+Copyright (c) 2025 Kubotal.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package protector
+
+import (
+	"context"
+	"io"
+	"kubauth/internal/proto"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+)
+
+func testCtx() context.Context {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	return logr.NewContextWithSlogLogger(context.Background(), logger)
+}
+
+// newBareProtector returns a *bfaProtector with the same defaults as
+// the production constructor but WITHOUT the cleaner goroutine — tests
+// drive `clean()` directly. Free failures = 0 and penaltyByFailure = 0
+// keep `failure()` from sleeping, so `ProtectLoginResult` returns
+// instantly. Override per test if needed.
+func newBareProtector() *bfaProtector {
+	return &bfaProtector{
+		stateByLogin:      make(map[string]*loginState),
+		cleanerPeriod:     60 * time.Second,
+		cleanDelay:        30 * time.Minute,
+		freeFailure:       0, // no free failures (so test penalties at all counts)
+		maxPenalty:        15 * time.Second,
+		penaltyByFailure:  0, // no actual sleep
+		maxPendingFailure: 20,
+	}
+}
+
+// delayFromFailureCount — pure function -----------------------------------
+
+func TestDelayFromFailureCount_BelowOrEqualFreeIsZero(t *testing.T) {
+	p := newBareProtector()
+	p.freeFailure = 4
+	p.penaltyByFailure = time.Second
+	p.maxPenalty = 15 * time.Second
+	for _, n := range []int64{0, 1, 2, 3, 4} {
+		if d := p.delayFromFailureCount(n); d != 0 {
+			t.Errorf("count=%d: expected 0 delay, got %v", n, d)
+		}
+	}
+}
+
+func TestDelayFromFailureCount_LinearAfterFree(t *testing.T) {
+	p := newBareProtector()
+	p.freeFailure = 4
+	p.penaltyByFailure = time.Second
+	p.maxPenalty = 15 * time.Second
+	for n, want := range map[int64]time.Duration{
+		5: 1 * time.Second,
+		6: 2 * time.Second,
+		7: 3 * time.Second,
+	} {
+		if d := p.delayFromFailureCount(n); d != want {
+			t.Errorf("count=%d: expected %v, got %v", n, want, d)
+		}
+	}
+}
+
+func TestDelayFromFailureCount_CappedAtMaxPenalty(t *testing.T) {
+	p := newBareProtector()
+	p.freeFailure = 4
+	p.penaltyByFailure = time.Second
+	p.maxPenalty = 5 * time.Second
+	if d := p.delayFromFailureCount(100); d != 5*time.Second {
+		t.Errorf("expected 5s cap, got %v", d)
+	}
+}
+
+func TestDelayFromFailureCount_ZeroPenaltyByFailureGivesZero(t *testing.T) {
+	p := newBareProtector() // penaltyByFailure = 0
+	p.freeFailure = 0
+	if d := p.delayFromFailureCount(50); d != 0 {
+		t.Errorf("zero penaltyByFailure should yield zero delay, got %v", d)
+	}
+}
+
+// empty Protector ---------------------------------------------------------
+
+func TestEmpty_AllOperationsAreNoOps(t *testing.T) {
+	e := empty{}
+	ctx := testCtx()
+	if e.EntryForLogin(ctx, "alice") {
+		t.Error("empty.EntryForLogin should never lock")
+	}
+	if e.EntryForToken(ctx) {
+		t.Error("empty.EntryForToken should never lock")
+	}
+	// These return nothing — just verify no panic.
+	e.TokenNotFound(ctx)
+	e.ProtectLoginResult(ctx, "alice", proto.PasswordFail)
+}
+
+// EntryForLogin / EntryForToken (locking) ---------------------------------
+
+func TestEntryForLogin_NoStateNotLocked(t *testing.T) {
+	p := newBareProtector()
+	if p.EntryForLogin(testCtx(), "alice") {
+		t.Error("fresh protector should not lock")
+	}
+}
+
+func TestEntryForLogin_LockedWhenPendingExceedsThreshold(t *testing.T) {
+	p := newBareProtector()
+	p.maxPendingFailure = 5
+	st := &loginState{}
+	st.pendingFailures.Add(6) // > 5
+	p.stateByLogin["alice"] = st
+	if !p.EntryForLogin(testCtx(), "alice") {
+		t.Error("expected lock when pending > maxPendingFailure")
+	}
+}
+
+func TestEntryForLogin_NotLockedAtThreshold(t *testing.T) {
+	// Strictly greater-than: at threshold exactly, NOT locked.
+	p := newBareProtector()
+	p.maxPendingFailure = 5
+	st := &loginState{}
+	st.pendingFailures.Add(5) // == 5
+	p.stateByLogin["alice"] = st
+	if p.EntryForLogin(testCtx(), "alice") {
+		t.Error("at-threshold should NOT lock (strict >)")
+	}
+}
+
+func TestEntryForLogin_UnknownUserPendingBlocksAllUsers(t *testing.T) {
+	// An attack against UnknownUser (probing random logins) should
+	// also lock specific user logins to defend the apiserver.
+	p := newBareProtector()
+	p.maxPendingFailure = 5
+	st := &loginState{}
+	st.pendingFailures.Add(10)
+	p.stateByLogin[UnknownUser] = st
+	if !p.EntryForLogin(testCtx(), "alice") {
+		t.Error("UnknownUser pending should lock specific logins")
+	}
+}
+
+func TestEntryForToken_NoStateNotLocked(t *testing.T) {
+	p := newBareProtector()
+	if p.EntryForToken(testCtx()) {
+		t.Error("fresh protector should not lock token entry")
+	}
+}
+
+func TestEntryForToken_LockedWhenUnknownTokenPendingHigh(t *testing.T) {
+	p := newBareProtector()
+	p.maxPendingFailure = 5
+	st := &loginState{}
+	st.pendingFailures.Add(10)
+	p.stateByLogin[UnknownToken] = st
+	if !p.EntryForToken(testCtx()) {
+		t.Error("UnknownToken pending should lock token entry")
+	}
+}
+
+// ProtectLoginResult ------------------------------------------------------
+
+func TestProtectLoginResult_PasswordFailRegistersFailure(t *testing.T) {
+	p := newBareProtector() // penaltyByFailure=0 → no sleep
+	p.ProtectLoginResult(testCtx(), "alice", proto.PasswordFail)
+	st, ok := p.stateByLogin["alice"]
+	if !ok {
+		t.Fatal("expected alice's state to exist after PasswordFail")
+	}
+	if st.nbrOfFailure != 1 {
+		t.Errorf("expected nbrOfFailure=1, got %d", st.nbrOfFailure)
+	}
+}
+
+func TestProtectLoginResult_InvalidOldPasswordRegistersFailure(t *testing.T) {
+	p := newBareProtector()
+	p.ProtectLoginResult(testCtx(), "alice", proto.InvalidOldPassword)
+	if _, ok := p.stateByLogin["alice"]; !ok {
+		t.Error("expected state after InvalidOldPassword")
+	}
+}
+
+func TestProtectLoginResult_NonFailureStatusesIgnored(t *testing.T) {
+	p := newBareProtector()
+	for _, st := range []proto.Status{
+		proto.PasswordChecked,
+		proto.PasswordMissing,
+		proto.PasswordUnchecked,
+		proto.UserNotFound,
+		proto.Disabled,
+		proto.Undefined,
+	} {
+		p.ProtectLoginResult(testCtx(), "alice", st)
+	}
+	if _, ok := p.stateByLogin["alice"]; ok {
+		t.Error("non-failure statuses should NOT register a failure")
+	}
+}
+
+func TestProtectLoginResult_RepeatedFailuresAccumulate(t *testing.T) {
+	p := newBareProtector()
+	for i := 0; i < 5; i++ {
+		p.ProtectLoginResult(testCtx(), "alice", proto.PasswordFail)
+	}
+	st := p.stateByLogin["alice"]
+	if st == nil || st.nbrOfFailure != 5 {
+		t.Errorf("expected 5 failures, got state=%v", st)
+	}
+}
+
+// TokenNotFound -----------------------------------------------------------
+
+func TestTokenNotFound_RegistersUnderUnknownTokenKey(t *testing.T) {
+	p := newBareProtector()
+	p.TokenNotFound(testCtx())
+	st, ok := p.stateByLogin[UnknownToken]
+	if !ok {
+		t.Fatal("expected state under UnknownToken key")
+	}
+	if st.nbrOfFailure != 1 {
+		t.Errorf("expected nbrOfFailure=1, got %d", st.nbrOfFailure)
+	}
+}
+
+// clean -------------------------------------------------------------------
+
+func TestClean_RemovesStaleStates(t *testing.T) {
+	p := newBareProtector()
+	p.cleanDelay = time.Hour
+	old := time.Now().Add(-2 * time.Hour) // way past cleanDelay
+	p.stateByLogin["alice"] = &loginState{lastFailure: old, nbrOfFailure: 3}
+	p.stateByLogin["bob"] = &loginState{lastFailure: old, nbrOfFailure: 1}
+
+	p.clean(testCtx())
+
+	if len(p.stateByLogin) != 0 {
+		t.Errorf("expected all stale states cleaned, got %v", p.stateByLogin)
+	}
+}
+
+func TestClean_KeepsRecentStates(t *testing.T) {
+	p := newBareProtector()
+	p.cleanDelay = time.Hour
+	recent := time.Now().Add(-5 * time.Minute) // well within cleanDelay
+	p.stateByLogin["alice"] = &loginState{lastFailure: recent, nbrOfFailure: 1}
+
+	p.clean(testCtx())
+
+	if _, ok := p.stateByLogin["alice"]; !ok {
+		t.Error("recent state should be kept")
+	}
+}
+
+func TestClean_MixedKeepsRecentDropsStale(t *testing.T) {
+	p := newBareProtector()
+	p.cleanDelay = time.Hour
+	now := time.Now()
+	p.stateByLogin["fresh"] = &loginState{lastFailure: now.Add(-10 * time.Minute)}
+	p.stateByLogin["stale"] = &loginState{lastFailure: now.Add(-3 * time.Hour)}
+
+	p.clean(testCtx())
+
+	if _, ok := p.stateByLogin["fresh"]; !ok {
+		t.Error("'fresh' should be kept")
+	}
+	if _, ok := p.stateByLogin["stale"]; ok {
+		t.Error("'stale' should be cleaned")
+	}
+}
+
+// New (constructor) -------------------------------------------------------
+
+func TestNew_DeactivatedReturnsEmpty(t *testing.T) {
+	ctx, cancel := context.WithCancel(testCtx())
+	defer cancel()
+	p := New(false, ctx)
+	if _, ok := p.(*empty); !ok {
+		t.Errorf("activated=false should return *empty, got %T", p)
+	}
+}
+
+func TestNew_ActivatedReturnsBfaProtector(t *testing.T) {
+	ctx, cancel := context.WithCancel(testCtx())
+	defer cancel() // cancel stops the cleaner goroutine
+	p := New(true, ctx)
+	if _, ok := p.(*bfaProtector); !ok {
+		t.Errorf("activated=true should return *bfaProtector, got %T", p)
+	}
+}
+
+func TestNew_OptionsApplied(t *testing.T) {
+	ctx, cancel := context.WithCancel(testCtx())
+	defer cancel()
+	p := New(true, ctx,
+		WithFreeFailure(7),
+		WithMaxPenalty(20*time.Second),
+		WithPenaltyByFailure(2*time.Second),
+		WithMaxPendingFailure(99),
+		WithCleanerPeriod(5*time.Minute),
+		WithCleanDelay(1*time.Hour),
+	).(*bfaProtector)
+	if p.freeFailure != 7 {
+		t.Errorf("freeFailure: %d", p.freeFailure)
+	}
+	if p.maxPenalty != 20*time.Second {
+		t.Errorf("maxPenalty: %v", p.maxPenalty)
+	}
+	if p.penaltyByFailure != 2*time.Second {
+		t.Errorf("penaltyByFailure: %v", p.penaltyByFailure)
+	}
+	if p.maxPendingFailure != 99 {
+		t.Errorf("maxPendingFailure: %d", p.maxPendingFailure)
+	}
+	if p.cleanerPeriod != 5*time.Minute {
+		t.Errorf("cleanerPeriod: %v", p.cleanerPeriod)
+	}
+	if p.cleanDelay != 1*time.Hour {
+		t.Errorf("cleanDelay: %v", p.cleanDelay)
+	}
+}

--- a/internal/handlers/protector/bfa_test.go
+++ b/internal/handlers/protector/bfa_test.go
@@ -324,7 +324,7 @@ func TestProtectLoginResult_AppliesRealDelayAndDecaysPending(t *testing.T) {
 	// While the goroutine is mid-sleep, pendingFailures must read 1. Poll
 	// briefly to avoid racing the goroutine's startup.
 	sawPending := false
-	deadline := time.Now().Add(penalty) // generous: whole penalty window
+	deadline := time.Now().Add(2 * time.Second) // bound goroutine startup, not the penalty window
 	for time.Now().Before(deadline) {
 		p.mu.Lock()
 		st := p.stateByLogin["alice"]

--- a/internal/handlers/protector/bfa_test.go
+++ b/internal/handlers/protector/bfa_test.go
@@ -297,6 +297,108 @@ func TestNew_ActivatedReturnsBfaProtector(t *testing.T) {
 	}
 }
 
+// real lockout delay / decay path ----------------------------------------
+
+func TestProtectLoginResult_AppliesRealDelayAndDecaysPending(t *testing.T) {
+	// Exercise the *real* penalty path (non-zero penaltyByFailure), not the
+	// instant no-op variant used elsewhere. We assert three things at once:
+	//   1. failure() actually sleeps for the computed delay (wall-clock),
+	//   2. pendingFailures is incremented for the duration of the sleep,
+	//   3. pendingFailures decays back to 0 once the call returns, while
+	//      nbrOfFailure (the persistent counter) keeps its increment.
+	const penalty = 60 * time.Millisecond
+	p := newBareProtector()
+	p.freeFailure = 0 // first failure already incurs a penalty
+	p.penaltyByFailure = penalty
+	p.maxPenalty = time.Second // well above a single step, so no capping here
+
+	// Run the (blocking, sleeping) failure on a goroutine so we can observe
+	// the in-flight pendingFailures increment from the test goroutine.
+	done := make(chan time.Duration, 1)
+	go func() {
+		start := time.Now()
+		p.ProtectLoginResult(testCtx(), "alice", proto.PasswordFail)
+		done <- time.Since(start)
+	}()
+
+	// While the goroutine is mid-sleep, pendingFailures must read 1. Poll
+	// briefly to avoid racing the goroutine's startup.
+	sawPending := false
+	deadline := time.Now().Add(penalty) // generous: whole penalty window
+	for time.Now().Before(deadline) {
+		p.mu.Lock()
+		st := p.stateByLogin["alice"]
+		p.mu.Unlock()
+		if st != nil && st.pendingFailures.Load() == 1 {
+			sawPending = true
+			break
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	if !sawPending {
+		t.Error("expected pendingFailures to be incremented to 1 during the lockout sleep")
+	}
+
+	elapsed := <-done
+	if elapsed < penalty {
+		t.Errorf("failure() should have slept at least %v (real delay path), slept %v", penalty, elapsed)
+	}
+
+	// After return: pending decayed to 0, persistent failure count is 1.
+	st := p.stateByLogin["alice"]
+	if st == nil {
+		t.Fatal("expected alice state after a real failure")
+	}
+	if got := st.pendingFailures.Load(); got != 0 {
+		t.Errorf("pendingFailures should decay to 0 after the call, got %d", got)
+	}
+	if st.nbrOfFailure != 1 {
+		t.Errorf("nbrOfFailure should be 1, got %d", st.nbrOfFailure)
+	}
+	if st.lastFailure.IsZero() {
+		t.Error("lastFailure should have been stamped")
+	}
+
+	// Decay/growth: a second failure (count=2) yields a strictly larger
+	// delay than the first (count=1), confirming the linear ramp is live.
+	start := time.Now()
+	p.ProtectLoginResult(testCtx(), "alice", proto.PasswordFail)
+	second := time.Since(start)
+	if second < 2*penalty {
+		t.Errorf("second failure (count=2) should sleep >= %v, slept %v", 2*penalty, second)
+	}
+	if st.nbrOfFailure != 2 {
+		t.Errorf("nbrOfFailure should be 2 after second failure, got %d", st.nbrOfFailure)
+	}
+	if got := st.pendingFailures.Load(); got != 0 {
+		t.Errorf("pendingFailures should again decay to 0, got %d", got)
+	}
+}
+
+func TestProtectLoginResult_DelayCappedAtMaxPenalty(t *testing.T) {
+	// The real path must honour the maxPenalty cap: with a huge per-failure
+	// step but a tiny cap, the inflicted sleep stays bounded by the cap and
+	// does not blow up to penaltyByFailure.
+	const cap = 40 * time.Millisecond
+	p := newBareProtector()
+	p.freeFailure = 0
+	p.penaltyByFailure = 10 * time.Second // would be enormous if uncapped
+	p.maxPenalty = cap
+
+	start := time.Now()
+	p.ProtectLoginResult(testCtx(), "alice", proto.PasswordFail)
+	elapsed := time.Since(start)
+
+	if elapsed < cap {
+		t.Errorf("delay should be at least the cap %v, got %v", cap, elapsed)
+	}
+	// Loose upper bound: nowhere near the uncapped 10s. Generous to absorb
+	// scheduler jitter on a busy CI box.
+	if elapsed > 2*time.Second {
+		t.Errorf("delay should be capped near %v, but slept %v (cap not applied?)", cap, elapsed)
+	}
+}
+
 func TestNew_OptionsApplied(t *testing.T) {
 	ctx, cancel := context.WithCancel(testCtx())
 	defer cancel()

--- a/internal/handlers/validator/validator_test.go
+++ b/internal/handlers/validator/validator_test.go
@@ -34,6 +34,9 @@ func TestOnlyGet_AllowsGET(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Errorf("code = %d, want 200 (nothing written for an allowed method)", rec.Code)
 	}
+	if rec.Body.Len() != 0 {
+		t.Errorf("an allowed method must not write a body, got %q", rec.Body.String())
+	}
 }
 
 func TestOnlyGet_RejectsNonGET(t *testing.T) {

--- a/internal/handlers/validator/validator_test.go
+++ b/internal/handlers/validator/validator_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright (c) 2025 Kubotal.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package validator
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"kubauth/internal/proto"
+
+	"github.com/go-logr/logr"
+)
+
+func testCtx() context.Context {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	return logr.NewContextWithSlogLogger(context.Background(), logger)
+}
+
+func TestOnlyGet_AllowsGET(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/identity", nil)
+	if ok := (OnlyGetValidator{}).Validate(rec, req, &proto.IdentityRequest{}); !ok {
+		t.Error("Validate(GET) = false, want true")
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("code = %d, want 200 (nothing written for an allowed method)", rec.Code)
+	}
+}
+
+func TestOnlyGet_RejectsNonGET(t *testing.T) {
+	// The reject path logs via the context logger, so the request must carry one.
+	for _, method := range []string{http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodPatch} {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(method, "/v1/identity", nil).WithContext(testCtx())
+		if ok := (OnlyGetValidator{}).Validate(rec, req, &proto.IdentityRequest{}); ok {
+			t.Errorf("Validate(%s) = true, want false", method)
+		}
+		if rec.Code != http.StatusMethodNotAllowed {
+			t.Errorf("%s: code = %d, want 405", method, rec.Code)
+		}
+	}
+}

--- a/internal/httpclient/httpclient_test.go
+++ b/internal/httpclient/httpclient_test.go
@@ -1,0 +1,369 @@
+/*
+Copyright (c) 2025 Kubotal.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package httpclient
+
+import (
+	"crypto/x509"
+	"encoding/base64"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// New() — URL validation -------------------------------------------------
+
+func TestNew_RejectsMalformedURL(t *testing.T) {
+	_, err := New(&Config{BaseURL: "://not-a-url"})
+	if err == nil {
+		t.Error("expected error on malformed URL")
+	}
+}
+
+func TestNew_RejectsUnsupportedScheme(t *testing.T) {
+	_, err := New(&Config{BaseURL: "ftp://example.org/"})
+	if err == nil {
+		t.Fatal("expected error on ftp:// scheme")
+	}
+	if !strings.Contains(err.Error(), "scheme") {
+		t.Errorf("error should mention 'scheme', got %q", err.Error())
+	}
+}
+
+func TestNew_AcceptsHTTPAndHTTPS(t *testing.T) {
+	for _, base := range []string{"http://example.org", "https://example.org", "HTTP://example.org", "HTTPS://example.org"} {
+		_, err := New(&Config{BaseURL: base})
+		if err != nil {
+			t.Errorf("unexpected error for %s: %v", base, err)
+		}
+	}
+}
+
+// New() — CA loading -----------------------------------------------------
+
+func TestNew_RejectsEmptyPEMBundle(t *testing.T) {
+	_, err := New(&Config{
+		BaseURL:     "https://example.org",
+		RootCaBytes: [][]byte{[]byte("")}, // empty entries are skipped, this should be fine
+	})
+	if err != nil {
+		t.Errorf("empty PEM entries should be skipped silently, got %v", err)
+	}
+}
+
+func TestNew_RejectsGarbagePEM(t *testing.T) {
+	_, err := New(&Config{
+		BaseURL:     "https://example.org",
+		RootCaBytes: [][]byte{[]byte("not pem data at all")},
+	})
+	if err == nil {
+		t.Fatal("expected error on garbage PEM")
+	}
+	if !strings.Contains(err.Error(), "PEM") && !strings.Contains(err.Error(), "CERTIFICATE") {
+		t.Errorf("error should mention PEM/CERTIFICATE, got %q", err.Error())
+	}
+}
+
+func TestNew_RejectsInvalidBase64(t *testing.T) {
+	_, err := New(&Config{
+		BaseURL:     "https://example.org",
+		RootCaDatas: []string{"!!!not-base64!!!"},
+	})
+	if err == nil {
+		t.Fatal("expected error on invalid base64")
+	}
+	if !strings.Contains(err.Error(), "base64") {
+		t.Errorf("error should mention 'base64', got %q", err.Error())
+	}
+}
+
+func TestNew_RejectsBase64ButNotPEM(t *testing.T) {
+	// Valid base64, but the decoded bytes aren't PEM.
+	garbage := base64.StdEncoding.EncodeToString([]byte("hello world, not pem"))
+	_, err := New(&Config{
+		BaseURL:     "https://example.org",
+		RootCaDatas: []string{garbage},
+	})
+	if err == nil {
+		t.Fatal("expected error when base64 decodes to non-PEM")
+	}
+}
+
+func TestNew_RejectsCAFileNotFound(t *testing.T) {
+	_, err := New(&Config{
+		BaseURL:     "https://example.org",
+		RootCaPaths: []string{"/no/such/ca/file/please.pem"},
+	})
+	if err == nil {
+		t.Fatal("expected error on missing CA file")
+	}
+	if !strings.Contains(err.Error(), "CA file") {
+		t.Errorf("error should mention 'CA file', got %q", err.Error())
+	}
+}
+
+func TestNew_HTTPSchemeSkipsCASetup(t *testing.T) {
+	// Plain http:// shouldn't try to load any CA — even invalid CA paths
+	// should be ignored because no TLS is configured.
+	_, err := New(&Config{
+		BaseURL:     "http://example.org",
+		RootCaPaths: []string{"/no/such/file.pem"}, // would error if validated
+	})
+	if err != nil {
+		t.Errorf("plain http should skip CA validation, got %v", err)
+	}
+}
+
+// appendCaFromPEM ---------------------------------------------------------
+
+func TestAppendCaFromPEM_RejectsEmptyInput(t *testing.T) {
+	pool := x509.NewCertPool()
+	_, err := appendCaFromPEM(pool, []byte{})
+	if err == nil {
+		t.Error("expected error on empty PEM")
+	}
+}
+
+func TestAppendCaFromPEM_RejectsNoCertificateBlock(t *testing.T) {
+	pool := x509.NewCertPool()
+	// Valid PEM structure but with a non-CERTIFICATE block type. Using
+	// a fictional `KUBAUTH TEST BLOCK` type rather than `PRIVATE KEY`
+	// so the literal doesn't trip secret-scanning hooks (gitleaks etc.)
+	// during commit — same parser path either way (block.Type !=
+	// "CERTIFICATE" ⇒ skipped ⇒ no subjects ⇒ error).
+	pem := []byte("-----BEGIN KUBAUTH TEST BLOCK-----\nZm9v\n-----END KUBAUTH TEST BLOCK-----\n")
+	_, err := appendCaFromPEM(pool, pem)
+	if err == nil {
+		t.Error("expected error when PEM has no CERTIFICATE blocks")
+	}
+}
+
+// Do() — HTTP behaviour --------------------------------------------------
+
+func newTestClient(t *testing.T, srv *httptest.Server, auth *HttpAuth) HttpClient {
+	t.Helper()
+	c, err := New(&Config{
+		BaseURL:  srv.URL,
+		HttpAuth: auth,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return c
+}
+
+func TestDo_HappyPathReturns200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+	c := newTestClient(t, srv, nil)
+
+	resp, err := c.Do("GET", "/foo", "application/json", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestDo_401ReturnsUnauthorizedError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(401)
+	}))
+	defer srv.Close()
+	c := newTestClient(t, srv, nil)
+
+	_, err := c.Do("GET", "/", "application/json", nil)
+	if err == nil {
+		t.Fatal("expected UnauthorizedError")
+	}
+	var ue *UnauthorizedError
+	if !errors.As(err, &ue) {
+		t.Errorf("expected *UnauthorizedError, got %T: %v", err, err)
+	}
+}
+
+func TestDo_404ReturnsNotFoundError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(404)
+	}))
+	defer srv.Close()
+	c := newTestClient(t, srv, nil)
+
+	_, err := c.Do("GET", "/missing", "application/json", nil)
+	if err == nil {
+		t.Fatal("expected NotFoundError")
+	}
+	var nfe *NotFoundError
+	if !errors.As(err, &nfe) {
+		t.Fatalf("expected *NotFoundError, got %T: %v", err, err)
+	}
+	if !strings.Contains(nfe.Error(), "/missing") {
+		t.Errorf("NotFoundError should include the URL, got %q", nfe.Error())
+	}
+}
+
+func TestDo_500ReturnsGenericError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(500)
+	}))
+	defer srv.Close()
+	c := newTestClient(t, srv, nil)
+
+	_, err := c.Do("GET", "/", "application/json", nil)
+	if err == nil {
+		t.Fatal("expected error on 500")
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Errorf("error should mention 500, got %q", err.Error())
+	}
+}
+
+func TestDo_SetsContentTypeHeader(t *testing.T) {
+	var seenCT string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenCT = r.Header.Get("Content-Type")
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+	c := newTestClient(t, srv, nil)
+
+	resp, err := c.Do("POST", "/", "application/x-www-form-urlencoded", strings.NewReader("a=1"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp.Body.Close()
+	if seenCT != "application/x-www-form-urlencoded" {
+		t.Errorf("content-type not propagated: got %q", seenCT)
+	}
+}
+
+func TestDo_BasicAuth(t *testing.T) {
+	var seenUser, seenPass string
+	var seenOK bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenUser, seenPass, seenOK = r.BasicAuth()
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+	c := newTestClient(t, srv, &HttpAuth{Login: "alice", Password: "s3cret"})
+
+	resp, err := c.Do("GET", "/", "application/json", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp.Body.Close()
+	if !seenOK || seenUser != "alice" || seenPass != "s3cret" {
+		t.Errorf("basic auth not set: ok=%v user=%q pass=%q", seenOK, seenUser, seenPass)
+	}
+}
+
+func TestDo_BearerToken(t *testing.T) {
+	var seenAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenAuth = r.Header.Get("Authorization")
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+	c := newTestClient(t, srv, &HttpAuth{Token: "abc.def.ghi"})
+
+	resp, err := c.Do("GET", "/", "application/json", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp.Body.Close()
+	if seenAuth != "Bearer abc.def.ghi" {
+		t.Errorf("expected 'Bearer abc.def.ghi', got %q", seenAuth)
+	}
+}
+
+func TestDo_NoAuthSetIfNotConfigured(t *testing.T) {
+	var seenAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenAuth = r.Header.Get("Authorization")
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+	c := newTestClient(t, srv, nil)
+
+	resp, err := c.Do("GET", "/", "application/json", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp.Body.Close()
+	if seenAuth != "" {
+		t.Errorf("expected no Authorization header, got %q", seenAuth)
+	}
+}
+
+func TestDo_JoinsBaseURLAndPath(t *testing.T) {
+	var seenPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenPath = r.URL.Path
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+	c := newTestClient(t, srv, nil)
+
+	resp, err := c.Do("GET", "/api/v1/users", "application/json", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp.Body.Close()
+	if seenPath != "/api/v1/users" {
+		t.Errorf("expected /api/v1/users, got %q", seenPath)
+	}
+}
+
+func TestDo_ConnectionRefusedSurfacesAsError(t *testing.T) {
+	// Bind a port, immediately close the server → next request gets refused.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
+	srv.Close() // server gone — its URL is a refused connection
+	c := newTestClient(t, srv, nil)
+
+	_, err := c.Do("GET", "/", "application/json", nil)
+	if err == nil {
+		t.Fatal("expected error on closed server")
+	}
+	if !strings.Contains(err.Error(), "http connection") {
+		t.Errorf("error should mention 'http connection', got %q", err.Error())
+	}
+}
+
+// Error types' Error() messages ------------------------------------------
+
+func TestUnauthorizedError_Message(t *testing.T) {
+	err := &UnauthorizedError{}
+	if err.Error() != "Unauthorized" {
+		t.Errorf("unexpected message: %q", err.Error())
+	}
+}
+
+func TestNotFoundError_MessageIncludesURL(t *testing.T) {
+	err := &NotFoundError{url: "https://example.org/nope"}
+	if !strings.Contains(err.Error(), "https://example.org/nope") {
+		t.Errorf("NotFoundError message should include URL, got %q", err.Error())
+	}
+}
+
+// GetBaseHttpDotClient ---------------------------------------------------
+
+func TestGetBaseHttpDotClient_ReturnsConfiguredClient(t *testing.T) {
+	c, err := New(&Config{BaseURL: "http://example.org"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if c.GetBaseHttpDotClient() == nil {
+		t.Error("GetBaseHttpDotClient returned nil")
+	}
+}

--- a/internal/httpclient/httpclient_test.go
+++ b/internal/httpclient/httpclient_test.go
@@ -47,7 +47,7 @@ func TestNew_AcceptsHTTPAndHTTPS(t *testing.T) {
 
 // New() — CA loading -----------------------------------------------------
 
-func TestNew_RejectsEmptyPEMBundle(t *testing.T) {
+func TestNew_SkipsEmptyPEMBundle(t *testing.T) {
 	_, err := New(&Config{
 		BaseURL:     "https://example.org",
 		RootCaBytes: [][]byte{[]byte("")}, // empty entries are skipped, this should be fine
@@ -108,7 +108,7 @@ func TestNew_RejectsCAFileNotFound(t *testing.T) {
 	}
 }
 
-func TestNew_HTTPSchemeSkipsCASetup(t *testing.T) {
+func TestNew_PlainHTTPSkipsCASetup(t *testing.T) {
 	// Plain http:// shouldn't try to load any CA — even invalid CA paths
 	// should be ignored because no TLS is configured.
 	_, err := New(&Config{

--- a/internal/httpclient/httpclient_test.go
+++ b/internal/httpclient/httpclient_test.go
@@ -170,7 +170,7 @@ func TestDo_HappyPathReturns200(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != 200 {
 		t.Errorf("expected 200, got %d", resp.StatusCode)
 	}
@@ -242,7 +242,7 @@ func TestDo_SetsContentTypeHeader(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	if seenCT != "application/x-www-form-urlencoded" {
 		t.Errorf("content-type not propagated: got %q", seenCT)
 	}
@@ -262,7 +262,7 @@ func TestDo_BasicAuth(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	if !seenOK || seenUser != "alice" || seenPass != "s3cret" {
 		t.Errorf("basic auth not set: ok=%v user=%q pass=%q", seenOK, seenUser, seenPass)
 	}
@@ -281,7 +281,7 @@ func TestDo_BearerToken(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	if seenAuth != "Bearer abc.def.ghi" {
 		t.Errorf("expected 'Bearer abc.def.ghi', got %q", seenAuth)
 	}
@@ -300,7 +300,7 @@ func TestDo_NoAuthSetIfNotConfigured(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	if seenAuth != "" {
 		t.Errorf("expected no Authorization header, got %q", seenAuth)
 	}
@@ -319,7 +319,7 @@ func TestDo_JoinsBaseURLAndPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	if seenPath != "/api/v1/users" {
 		t.Errorf("expected /api/v1/users, got %q", seenPath)
 	}

--- a/internal/misc/expandenv.go
+++ b/internal/misc/expandenv.go
@@ -88,6 +88,10 @@ func ExpandEnv(s string) (string, error) {
 				output = append(output, []byte(value)...)
 				chunkStart = i + 1
 				chunkEnd = -1
+				// Return to nominal state — without this, the next `$`
+				// is consumed by this case's fallthrough and adjacent
+				// variables (`${A}${B}`) leave the second unexpanded.
+				state = STATE_NOMINAL
 			} else if isAlphanumeric(s[i]) {
 				variable = append(variable, s[i])
 			} else {

--- a/internal/misc/expandenv_test.go
+++ b/internal/misc/expandenv_test.go
@@ -1,0 +1,169 @@
+/*
+Copyright (c) 2025 Kubotal.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package misc
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestExpandEnv_NoVariables(t *testing.T) {
+	got, err := ExpandEnv("plain text without dollars")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "plain text without dollars" {
+		t.Errorf("got %q, want passthrough", got)
+	}
+}
+
+func TestExpandEnv_EmptyInput(t *testing.T) {
+	got, err := ExpandEnv("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "" {
+		t.Errorf("got %q, want empty", got)
+	}
+}
+
+func TestExpandEnv_SingleVariable(t *testing.T) {
+	t.Setenv("KUBAUTH_TEST_X", "hello")
+	got, err := ExpandEnv("greet=${KUBAUTH_TEST_X}")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "greet=hello" {
+		t.Errorf("got %q, want %q", got, "greet=hello")
+	}
+}
+
+func TestExpandEnv_MultipleVariables(t *testing.T) {
+	t.Setenv("KUBAUTH_TEST_HOST", "localhost")
+	t.Setenv("KUBAUTH_TEST_PORT", "443")
+	got, err := ExpandEnv("https://${KUBAUTH_TEST_HOST}:${KUBAUTH_TEST_PORT}/oauth")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "https://localhost:443/oauth" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestExpandEnv_LoneDollarIsLiteral(t *testing.T) {
+	// "Difference from os.ExpandEnv: A single '$' is not taken in account."
+	// Documented as a deliberate divergence — verify it stays that way.
+	got, err := ExpandEnv("price is $5 not ${X}")
+	// `${X}` is undefined → MissingVariableError. The lone $ before is
+	// passed through literally (the contract under test).
+	if err == nil {
+		t.Fatalf("expected error for missing X, got nil with output %q", got)
+	}
+	var mv MissingVariableError
+	if !errors.As(err, &mv) {
+		t.Errorf("expected MissingVariableError, got %T: %v", err, err)
+	}
+}
+
+func TestExpandEnv_LoneDollarPassesThrough(t *testing.T) {
+	got, err := ExpandEnv("price is $5 net")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "price is $5 net" {
+		t.Errorf("lone `$` should pass through as-is, got %q", got)
+	}
+}
+
+func TestExpandEnv_MissingVariableError(t *testing.T) {
+	t.Setenv("KUBAUTH_TEST_DEFINED", "ok")
+	_, err := ExpandEnv("foo=${KUBAUTH_TEST_NOT_DEFINED_XYZ_42}")
+	if err == nil {
+		t.Fatal("expected MissingVariableError")
+	}
+	var mv MissingVariableError
+	if !errors.As(err, &mv) {
+		t.Fatalf("expected MissingVariableError, got %T: %v", err, err)
+	}
+	if !strings.Contains(err.Error(), "KUBAUTH_TEST_NOT_DEFINED_XYZ_42") {
+		t.Errorf("error should mention the missing var name, got %q", err.Error())
+	}
+}
+
+func TestExpandEnv_MissingVariableErrorReportsLineNumber(t *testing.T) {
+	input := "line1: ok\nline2: ok\nline3: ${KUBAUTH_TEST_MISSING_LINE_TEST}"
+	_, err := ExpandEnv(input)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "line 3") {
+		t.Errorf("expected error to report 'line 3', got %q", err.Error())
+	}
+}
+
+func TestExpandEnv_VariableInsideText(t *testing.T) {
+	t.Setenv("KUBAUTH_TEST_NAME", "alice")
+	got, err := ExpandEnv("hello ${KUBAUTH_TEST_NAME}, welcome")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "hello alice, welcome" {
+		t.Errorf("got %q", got)
+	}
+}
+
+// TestExpandEnv_AdjacentVariables verifies that two `${...}` blocks with
+// no separator between them both expand correctly. Prior to the
+// `state = STATE_NOMINAL` reset after the closing `}`, the parser
+// stayed in STATE_IN_VAR and consumed the next `$` as a non-`}` non-
+// alphanumeric → silently dropped the second variable, producing
+// `<A-value>${B}` instead of the concatenation.
+func TestExpandEnv_AdjacentVariables(t *testing.T) {
+	t.Setenv("KUBAUTH_TEST_A", "ab")
+	t.Setenv("KUBAUTH_TEST_B", "cd")
+	got, err := ExpandEnv("${KUBAUTH_TEST_A}${KUBAUTH_TEST_B}")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "abcd" {
+		t.Errorf("got %q, want %q", got, "abcd")
+	}
+}
+
+func TestExpandEnv_VariableNamesAcceptUnderscoreAndDigits(t *testing.T) {
+	t.Setenv("KUBAUTH_TEST_VAR_42", "ok")
+	got, err := ExpandEnv("v=${KUBAUTH_TEST_VAR_42}")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "v=ok" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestExpandEnv_InvalidCharInVariableNameRejected(t *testing.T) {
+	// `${FOO-BAR}` is not a valid variable name (hyphen not alphanumeric).
+	// Per the parser: the whole `${...}` chunk is dropped from output and
+	// treated as if no expansion happened. No error raised — by design.
+	got, err := ExpandEnv("v=${FOO-BAR}")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(got, "FOO-BAR") {
+		t.Errorf("invalid var name should be passed through literally, got %q", got)
+	}
+}
+
+func TestMissingVariableError_FormatsHumanReadable(t *testing.T) {
+	err := MissingVariableError{line: 7, variable: "MY_VAR"}
+	msg := err.Error()
+	if !strings.Contains(msg, "MY_VAR") || !strings.Contains(msg, "line 7") {
+		t.Errorf("error message should mention var name and line number, got %q", msg)
+	}
+}

--- a/internal/misc/expandenv_test.go
+++ b/internal/misc/expandenv_test.go
@@ -149,8 +149,8 @@ func TestExpandEnv_VariableNamesAcceptUnderscoreAndDigits(t *testing.T) {
 
 func TestExpandEnv_InvalidCharInVariableNameRejected(t *testing.T) {
 	// `${FOO-BAR}` is not a valid variable name (hyphen not alphanumeric).
-	// Per the parser: the whole `${...}` chunk is dropped from output and
-	// treated as if no expansion happened. No error raised — by design.
+	// Per the parser the chunk is left in the output verbatim (no expansion
+	// and no error), not dropped.
 	got, err := ExpandEnv("v=${FOO-BAR}")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/internal/misc/loadconfig_test.go
+++ b/internal/misc/loadconfig_test.go
@@ -1,0 +1,148 @@
+/*
+Copyright (c) 2025 Kubotal.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package misc
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// helpers --------------------------------------------------------------
+
+func writeTempConfig(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatalf("writing temp config: %v", err)
+	}
+	return p
+}
+
+// tests ----------------------------------------------------------------
+
+func TestLoadConfig_ParsesYAMLIntoStruct(t *testing.T) {
+	type cfg struct {
+		Name string `yaml:"name"`
+		Port int    `yaml:"port"`
+	}
+	path := writeTempConfig(t, "name: kubauth\nport: 6801\n")
+	var c cfg
+	abs, err := LoadConfig(path, &c)
+	if err != nil {
+		t.Fatalf("LoadConfig error: %v", err)
+	}
+	if !filepath.IsAbs(abs) {
+		t.Errorf("returned path should be absolute, got %q", abs)
+	}
+	if c.Name != "kubauth" || c.Port != 6801 {
+		t.Errorf("config not parsed: %+v", c)
+	}
+}
+
+func TestLoadConfig_ExpandsEnvBeforeParsing(t *testing.T) {
+	t.Setenv("KUBAUTH_TEST_NAME", "alice")
+	type cfg struct {
+		User string `yaml:"user"`
+	}
+	path := writeTempConfig(t, "user: ${KUBAUTH_TEST_NAME}\n")
+	var c cfg
+	if _, err := LoadConfig(path, &c); err != nil {
+		t.Fatalf("LoadConfig error: %v", err)
+	}
+	if c.User != "alice" {
+		t.Errorf("env var not expanded: %+v", c)
+	}
+}
+
+func TestLoadConfig_MissingEnvVarSurfacesAsError(t *testing.T) {
+	type cfg struct {
+		User string `yaml:"user"`
+	}
+	path := writeTempConfig(t, "user: ${KUBAUTH_TEST_DOES_NOT_EXIST_8472}\n")
+	var c cfg
+	_, err := LoadConfig(path, &c)
+	if err == nil {
+		t.Fatal("expected MissingVariableError, got nil")
+	}
+	if !strings.Contains(err.Error(), "KUBAUTH_TEST_DOES_NOT_EXIST_8472") {
+		t.Errorf("error should mention the missing var, got %q", err.Error())
+	}
+}
+
+func TestLoadConfig_FileNotFound(t *testing.T) {
+	type cfg struct{}
+	abs, err := LoadConfig("/no/such/file/at/all/please.yaml", &cfg{})
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+	if !filepath.IsAbs(abs) {
+		t.Errorf("returned path should still be absolute even on read error, got %q", abs)
+	}
+	if !os.IsNotExist(err) && !strings.Contains(err.Error(), "no such file") {
+		t.Errorf("expected file-not-found, got %v", err)
+	}
+}
+
+func TestLoadConfig_RejectsUnknownYAMLFields(t *testing.T) {
+	// LoadConfig sets `decoder.SetStrict(true)` — unknown fields must error.
+	// This protects against silent typos in production configs.
+	type cfg struct {
+		Name string `yaml:"name"`
+	}
+	path := writeTempConfig(t, "name: ok\nunknown_field: should_error\n")
+	var c cfg
+	_, err := LoadConfig(path, &c)
+	if err == nil {
+		t.Fatal("expected strict-mode error for unknown field")
+	}
+	if !strings.Contains(err.Error(), "unknown_field") {
+		t.Errorf("error should mention the unknown field, got %q", err.Error())
+	}
+}
+
+func TestLoadConfig_EmptyFileIsNotAnError(t *testing.T) {
+	type cfg struct {
+		Name string `yaml:"name"`
+	}
+	path := writeTempConfig(t, "")
+	var c cfg
+	if _, err := LoadConfig(path, &c); err != nil {
+		t.Fatalf("empty file should not error, got %v", err)
+	}
+	if c.Name != "" {
+		t.Errorf("empty file should leave struct zero-valued, got %+v", c)
+	}
+}
+
+func TestLoadConfig_RelativePathBecomesAbsolute(t *testing.T) {
+	type cfg struct {
+		Name string `yaml:"name"`
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "rel.yaml")
+	if err := os.WriteFile(path, []byte("name: ok\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Use a relative path by chdir'ing into the temp dir.
+	cwd, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	var c cfg
+	abs, err := LoadConfig("rel.yaml", &c)
+	if err != nil {
+		t.Fatalf("LoadConfig error: %v", err)
+	}
+	if !filepath.IsAbs(abs) {
+		t.Errorf("expected absolute path back, got %q", abs)
+	}
+}

--- a/internal/misc/loadconfig_test.go
+++ b/internal/misc/loadconfig_test.go
@@ -132,7 +132,10 @@ func TestLoadConfig_RelativePathBecomesAbsolute(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Use a relative path by chdir'ing into the temp dir.
-	cwd, _ := os.Getwd()
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
 	t.Cleanup(func() { _ = os.Chdir(cwd) })
 	if err := os.Chdir(dir); err != nil {
 		t.Fatal(err)

--- a/internal/misc/merge.go
+++ b/internal/misc/merge.go
@@ -16,8 +16,6 @@ limitations under the License.
 
 package misc
 
-import "fmt"
-
 // MergeMaps merge two maps and return a new one.
 // Second parameter map will override the first one, except:
 // for a given key, if both values are []string, the result is deduplicated concatenation
@@ -30,7 +28,6 @@ func MergeMaps(a, b map[string]interface{}) map[string]interface{} {
 		out[k] = v
 	}
 	for k, v := range b {
-		fmt.Printf("Key: %s, b Value type: %T   a Value Type:%T\n", k, v, out[k])
 		if v, ok := v.(map[string]interface{}); ok {
 			if bv, ok := out[k]; ok {
 				if bv, ok := bv.(map[string]interface{}); ok {

--- a/internal/misc/misc_test.go
+++ b/internal/misc/misc_test.go
@@ -1,0 +1,178 @@
+/*
+Copyright (c) 2025 Kubotal.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package misc
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestBoolPtrFalse(t *testing.T) {
+	tt := true
+	ff := false
+	cases := []struct {
+		name string
+		in   *bool
+		want bool
+	}{
+		{"nil → false", nil, false},
+		{"&true → true", &tt, true},
+		{"&false → false", &ff, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := BoolPtrFalse(tc.in); got != tc.want {
+				t.Errorf("BoolPtrFalse(%v) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBoolPtrTrue(t *testing.T) {
+	tt := true
+	ff := false
+	cases := []struct {
+		name string
+		in   *bool
+		want bool
+	}{
+		{"nil → true (default)", nil, true},
+		{"&true → true", &tt, true},
+		{"&false → false", &ff, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := BoolPtrTrue(tc.in); got != tc.want {
+				t.Errorf("BoolPtrTrue(%v) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestShortenString(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty stays empty", "", ""},
+		{"30 chars stays whole", strings.Repeat("a", 30), strings.Repeat("a", 30)},
+		{"31 chars gets shortened", strings.Repeat("a", 31), "aaaaaaaaaa.......aaaaaaaaaa"},
+		{"long token is shortened with marker", "abcdefghij" + strings.Repeat("Z", 50) + "0123456789", "abcdefghij.......0123456789"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ShortenString(tc.in)
+			if got != tc.want {
+				t.Errorf("ShortenString(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDedupAndSort(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{"nil input → empty slice", nil, []string{}},
+		{"empty input → empty slice", []string{}, []string{}},
+		{"unique already sorted", []string{"a", "b", "c"}, []string{"a", "b", "c"}},
+		{"sorts unsorted unique", []string{"c", "a", "b"}, []string{"a", "b", "c"}},
+		{"removes duplicates", []string{"b", "a", "b", "c", "a"}, []string{"a", "b", "c"}},
+		{"single element", []string{"x"}, []string{"x"}},
+		{"all duplicates", []string{"x", "x", "x"}, []string{"x"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := DedupAndSort(tc.in)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("DedupAndSort(%v) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAppendIfNotPresent(t *testing.T) {
+	cases := []struct {
+		name  string
+		slice []string
+		items []string
+		want  []string
+	}{
+		{
+			name:  "appends new items in order",
+			slice: []string{"a", "b"},
+			items: []string{"c", "d"},
+			want:  []string{"a", "b", "c", "d"},
+		},
+		{
+			name:  "skips items already in slice",
+			slice: []string{"a", "b"},
+			items: []string{"b", "c"},
+			want:  []string{"a", "b", "c"},
+		},
+		{
+			name:  "deduplicates within items",
+			slice: []string{"a"},
+			items: []string{"b", "b", "c", "c"},
+			want:  []string{"a", "b", "c"},
+		},
+		{
+			name:  "empty items: slice unchanged",
+			slice: []string{"a", "b"},
+			items: nil,
+			want:  []string{"a", "b"},
+		},
+		{
+			name:  "empty slice: items dedup'd into result",
+			slice: nil,
+			items: []string{"x", "y", "x"},
+			want:  []string{"x", "y"},
+		},
+		{
+			name:  "preserves slice order even when items reordered",
+			slice: []string{"z", "a"},
+			items: []string{"a", "z", "b"},
+			want:  []string{"z", "a", "b"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := AppendIfNotPresent(tc.slice, tc.items)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("AppendIfNotPresent(%v, %v) = %v, want %v", tc.slice, tc.items, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCountTrue(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []bool
+		want int
+	}{
+		{"none", nil, 0},
+		{"all false", []bool{false, false, false}, 0},
+		{"all true", []bool{true, true, true}, 3},
+		{"mixed", []bool{true, false, true, false, true}, 3},
+		{"single true", []bool{true}, 1},
+		{"single false", []bool{false}, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := CountTrue(tc.in...)
+			if got != tc.want {
+				t.Errorf("CountTrue(%v) = %d, want %d", tc.in, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

The first substantial unit-test suite for kubauth, plus three production fixes surfaced
while writing the tests and a small CI config tweak.

**Closes #37.**

### Tests (httptest- and fake-client-backed, no envtest)

- OIDC core: `oidcserver`, `oidcstorage`, `sessioncodec`, `sessionstore`, `fositepatch`, `upstreams`
- Auth providers: `oidc/authenticator/httpprovider`, `merger/provider`, `audit/authenticator`
- Supporting: `ucrd/authenticator`, `internal/handlers/{protector,validator}`, `internal/httpclient`, `internal/misc`

Sociable tests throughout: real fosite (`ComposeAllEnabled`), real RSA signing with a JWKS
round-trip and signature verification, a real go-oidc verifier against an httptest upstream,
and the controller-runtime fake client with interceptors for the fail-closed paths.

### Production fixes (each with a regression test that fails when the fix is reverted)

- **fix(oidc)** `httpprovider` dropped groups/emails carried inside the upstream claims map
  (`m["key"]` instead of `m[key]`). **Closes #37.**
- **fix(misc)** `ExpandEnv` left the second of two adjacent `${A}${B}` variables unexpanded.
- **fix** `kubessostore` could log on a nil logger (panic via the non-Ctx wrappers), and a
  stray debug print was removed from `merge.go`.

### CI

- Relax `gosec` + `bodyclose` for `*_test.go` only (fixture credentials, temp-file perms,
  nil-response error paths). Production code stays strict.

## Coverage (key packages)

`httpprovider` 94.7%, `merger/provider` 100%, `audit/authenticator` 97.4%, `validator` 100%,
`oidcstorage` 96%, `fositepatch` 95%, `sessioncodec` 100%, `protector` 99%, `ucrd/authenticator` 93%.

## Verification

`go build` / `go vet` / `go test -race ./...` green. golangci gate (`--new-from-rev=origin/main`)
clean. Self-reviewed via a 3-agent adversarial pass: vacuous authorize/introspection assertions
strengthened, User/Group `Get` fail-closed tests added, and a flaky bfa timing test stabilized.

## Follow-ups (tracked, out of scope here)

- #38 - `/userinfo` returns all claims regardless of granted scope (pre-existing).
- Upstream-callback success-path coverage and the remaining packages go in the next test PR.
