### PR TITLE
fix(oidc): accept case-insensitive Bearer scheme on /userinfo

### DIFF
--- a/cmd/oidc/oidcserver/handle-user-info.go
+++ b/cmd/oidc/oidcserver/handle-user-info.go
@@ -31,14 +31,18 @@ func (s *OIDCServer) handleUserInfo(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	logger := logr.FromContextAsSlogLogger(ctx)
 
+	// HTTP auth schemes are case-insensitive (RFC 7235). We advertise token_type
+	// "bearer" (lowercase), so a compliant client sends "Authorization: bearer
+	// <token>". Match the scheme case-insensitively so we accept our own casing.
+	const bearerPrefix = "Bearer "
 	authz := r.Header.Get("Authorization")
-	if authz == "" || !strings.HasPrefix(authz, "Bearer ") {
+	if len(authz) < len(bearerPrefix) || !strings.EqualFold(authz[:len(bearerPrefix)], bearerPrefix) {
 		logger.Error("missing bearer token on userinfo handler")
 		w.Header().Set("WWW-Authenticate", "Bearer error=\"invalid_token\", error_description=\"missing bearer token\"")
 		http.Error(w, "unauthorized", http.StatusUnauthorized)
 		return
 	}
-	accessToken := strings.TrimPrefix(authz, "Bearer ")
+	accessToken := authz[len(bearerPrefix):]
 
 	_, ar, err := s.oauth2.IntrospectToken(ctx, accessToken, fosite.AccessToken, s.newSession(nil, GetClientIdFromRequest(r)), "openid")
 	if err != nil {

--- a/cmd/oidc/oidcserver/handle_userinfo_test.go
+++ b/cmd/oidc/oidcserver/handle_userinfo_test.go
@@ -69,6 +69,41 @@ func TestUserInfo_MissingAuthorizationHeader_Returns401(t *testing.T) {
 	}
 }
 
+// The HTTP Authorization scheme is case-insensitive (RFC 7235), and we advertise
+// token_type "bearer" (lowercase), so compliant clients (including the OpenID
+// conformance suite) send "Authorization: bearer <token>". The handler must accept
+// that casing. Regression test for the /userinfo 401 that failed the oidcc-basic
+// certification plan.
+func TestUserInfo_LowercaseBearerScheme_ReturnsSubAndClaims(t *testing.T) {
+	ts := buildServer(t)
+	accessToken := ts.accessTokenForUser(t, "openid profile email")
+
+	for _, scheme := range []string{"bearer", "BEARER", "BeArEr"} {
+		t.Run(scheme, func(t *testing.T) {
+			req := newGet(t, "/userinfo")
+			req.Header.Set("Authorization", scheme+" "+accessToken)
+			rr := ts.do(req)
+
+			if rr.Code != http.StatusOK {
+				t.Fatalf("userinfo with %q scheme: got %d body=%q, want 200", scheme, rr.Code, rr.Body.String())
+			}
+			// Assert the full mapped claim set, not just sub: a case-insensitive
+			// scheme match must still resolve the token and project its claims,
+			// exactly like the canonical "Bearer" path.
+			claims := decodeJSON(t, rr)
+			if sub, _ := claims["sub"].(string); sub != testUserLogin {
+				t.Errorf("sub: got %q, want %q", sub, testUserLogin)
+			}
+			if email, _ := claims["email"].(string); email != "alice@test" {
+				t.Errorf("email: got %q, want alice@test", email)
+			}
+			if name, _ := claims["name"].(string); name != "Alice Example" {
+				t.Errorf("name: got %q, want Alice Example", name)
+			}
+		})
+	}
+}
+
 func TestUserInfo_NonBearerScheme_Returns401(t *testing.T) {
 	ts := buildServer(t)
 


### PR DESCRIPTION
## What

`/userinfo` matched the HTTP `Authorization` scheme case-sensitively, so it rejected the lowercase `bearer` scheme kubauth itself advertises. Match it case-insensitively (RFC 7235) and add a regression test.

## Why

The token endpoint returns `token_type: "bearer"` (lowercase). A spec-compliant client that echoes that scheme sends `Authorization: bearer <token>`, and the handler rejected it with `401 "missing bearer token"` against a valid, freshly issued access token. Every happy-flow module of the `oidcc-basic` OpenID certification plan fetches `/userinfo` as its final step, so this single mismatch failed most of the plan (about 19 modules).

## How

- `handle-user-info.go`: match the scheme with `strings.EqualFold` on the fixed 7-char prefix, then slice the token by that length. A non-Bearer scheme (e.g. `Basic`) and a missing header still return 401 with a `WWW-Authenticate` challenge.
- New test `TestUserInfo_LowercaseBearerScheme_ReturnsSubAndClaims` (`bearer` / `BEARER` / `BeArEr`): returns 401 on the old handler and 200 on the fix. Verified by stashing the fix and re-running (401 on old, 200 on new).

Closes #43

Surfaced by the autonomous conformance harness (#41): the `oidcc-basic` plan flagged UserInfo 401s across every happy-flow module.
